### PR TITLE
Github migration - post clean up for BAV CRIbackend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-# This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipv-cri-f2f-api repository
+# This is the CODEOWNERS file. These owners will be the default owners for everything in the ipv-cri-bav-api repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @alphagov/di-ipv-kiwi-api-codeowners
+* @govuk-one-login/kiwi-api-codeowners
 
 # The following allows QA to review changes to /tests directory
 
-tests/ @alphagov/di-ipv-kiwi-qa-codeowners @alphagov/di-ipv-kiwi-api-codeowners
+tests/ @govuk-one-login/kiwi-qa-codeowners @govuk-one-login/kiwi-api-codeowners

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "BAV",
   "version": "1.0.0",
   "description": "OneLogin BAV CRI",
-  "repository": "https://github.com/alphagov/di-ipv-cri-bav-api",
+  "repository": "https://github.com/govuk-one-login/ipv-cri-bav-api",
   "author": "GDS",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
- Add the CODEOWNERS for new govuk-one-login github BAV API
- Modified the urls pointing to alphagov github repository

- [KIWI-1323](https://govukverify.atlassian.net/browse/KIWI-1323)

[KIWI-1323]: https://govukverify.atlassian.net/browse/KIWI-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ