### PR TITLE
KIWI-1262: Add BAV CRI Api repos on Sonar

### DIFF
--- a/.github/workflows/pull-request-sonar.yml
+++ b/.github/workflows/pull-request-sonar.yml
@@ -1,0 +1,40 @@
+name: Pull Request CI - Sonar
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+  run-code-analysis:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: src/
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Setup nodeJS v18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install
+      - name: Test and coverage
+        run: npm run test:unit -- --coverage
+      - name: "Run SonarCloud Scan"
+        if: ${{ success() }}
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=alphagov_di-ipv-cri-bav-api
+sonar.organization=alphagov
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=src/
+sonar.exclusions=src/tests/**/*.*,src/jest.config.ts,src/jest.setup.ts
+sonar.tests=src/
+sonar.test.inclusions=**/*.test.ts
+sonar.javascript.lcov.reportPaths=src/coverage/lcov.info
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=ipv-cri-bav-api
+sonar.projectKey=govuk-one-login_ipv-cri-bav-api
 sonar.organization=govuk-one-login
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=alphagov_di-ipv-cri-bav-api
-sonar.organization=alphagov
+sonar.projectKey=ipv-cri-bav-api
+sonar.organization=govuk-one-login
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=govuk-one-login_ipv-cri-bav-api
+sonar.projectKey=ipv-cri-bav-api
 sonar.organization=govuk-one-login
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.


### PR DESCRIPTION
### What changed
- Create a BAV CRI API workspace on sonar cloud
- Add SONAR_TOKEN on github repo secrets
- Create properties and workflows for sonar

### Issue tracking

- [KIWI-1262](https://govukverify.atlassian.net/browse/KIWI-1262)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1262]: https://govukverify.atlassian.net/browse/KIWI-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ