### PR TITLE
Kiwi 1256 QA Authorisation tests

### DIFF
--- a/src/tests/api/BavHappyPath.test.ts
+++ b/src/tests/api/BavHappyPath.test.ts
@@ -19,6 +19,7 @@ describe("Test BAV End Points", () => {
         //Session Request
        sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
     });
+
     it("E2E BAV End Points Happy Path Journey", async () => {
         expect(sessionId).toBeTruthy();
 
@@ -37,15 +38,7 @@ describe("Test BAV End Points", () => {
         // const userInfoResponse = await userInfoPost("Bearer " + tokenResponse.data.access_token);
         // expect(userInfoResponse).toBe(202);
     });
-});
 
-describe("Test BAV End Points", () => {
-    let sessionId: any;
-
-    beforeEach(async () => {
-        //Session Request
-       sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
-    });
     it.skip("E2E BAV End Points Happy Path Journey", async () => {
         expect(sessionId).toBeTruthy();
       
@@ -71,16 +64,7 @@ describe("Test BAV End Points", () => {
         // const userInfoResponse = await userInfoPost("Bearer " + tokenResponse.data.access_token);
         // expect(userInfoResponse).toBe(202);
     });
-});
 
-
-describe("Happy Path Test for Repeat Authorisation", () => {
-    let sessionId: any;
-
-    beforeEach(async () => {
-        //Session Request
-        sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);   
-    });
 
     it.skip("Happy Path /authorisation endpoint - Repeated request made", async () => {
         // verifyAccount endpoint
@@ -91,6 +75,7 @@ describe("Happy Path Test for Repeat Authorisation", () => {
         const authRepeatResponseCode = authRepeatResponse.data.authorizationCode;
         expect(authCode).not.toEqual(authRepeatResponseCode); 
     });
+    
 });
 
 describe("E2E Happy Path Well Known Endpoint", () => {

--- a/src/tests/api/BavHappyPath.test.ts
+++ b/src/tests/api/BavHappyPath.test.ts
@@ -19,19 +19,11 @@ describe("Test BAV End Points", () => {
         //Session Request
        sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
     });
-    it.skip("E2E BAV End Points Happy Path Journey", async () => {
+    it("E2E BAV End Points Happy Path Journey", async () => {
         expect(sessionId).toBeTruthy();
 
-      
-        // Authorization
-        const authResponse = await authorizationGet(sessionId);
-        expect(authResponse.status).toBe(200);
-        expect(authResponse.data.authorizationCode).toBeTruthy();
-        expect(authResponse.data.redirect_uri).toBeTruthy();
-        expect(authResponse.data.state).toBeTruthy();
-
         // Make sure authSession state is as expected
-        await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_AUTH_CODE_ISSUED");
+        await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_SESSION_CREATED");
 
         // Make sure txma event is present & valid
         const sqsMessage = await getSqsEventList("txma/", sessionId, 1);
@@ -46,6 +38,41 @@ describe("Test BAV End Points", () => {
         // expect(userInfoResponse).toBe(202);
     });
 });
+
+describe("Test BAV End Points", () => {
+    let sessionId: any;
+
+    beforeEach(async () => {
+        //Session Request
+       sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
+    });
+    it.skip("E2E BAV End Points Happy Path Journey", async () => {
+        expect(sessionId).toBeTruthy();
+      
+        // Authorization
+        const authResponse = await authorizationGet(sessionId);
+        expect(authResponse.status).toBe(200);
+        expect(authResponse.data.authorizationCode).toBeTruthy();
+        expect(authResponse.data.redirect_uri).toBeTruthy();
+        expect(authResponse.data.state).toBeTruthy();
+
+        // Make sure authSession state is as expected
+        await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_AUTH_CODE_ISSUED");
+
+        // Make sure txma event is present & valid
+        const sqsMessage = await getSqsEventList("txma/", sessionId, 2);
+        await validateTxMAEventData(sqsMessage);
+        
+        // // Commented out until /token (KIWI-1260) and /userInfo (KIWI-1258) endpoints are available
+        // // Token
+        // const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri);
+        // expect(tokenResponse).toBe(200);
+        // // User Info
+        // const userInfoResponse = await userInfoPost("Bearer " + tokenResponse.data.access_token);
+        // expect(userInfoResponse).toBe(202);
+    });
+});
+
 
 describe("Happy Path Test for Repeat Authorisation", () => {
     let sessionId: any;
@@ -67,7 +94,7 @@ describe("Happy Path Test for Repeat Authorisation", () => {
 });
 
 describe("E2E Happy Path Well Known Endpoint", () => {
-    it.skip("E2E Happy Path Journey - Well Known", async () => {
+    it("E2E Happy Path Journey - Well Known", async () => {
         // Well Known
         const wellKnownResponse = await wellKnownGet();
         validateWellKnownResponse(wellKnownResponse.data);

--- a/src/tests/api/BavHappyPath.test.ts
+++ b/src/tests/api/BavHappyPath.test.ts
@@ -20,7 +20,7 @@ describe("Test BAV End Points", () => {
        sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
     });
 
-    it("E2E BAV End Points Happy Path Journey", async () => {
+    it("BAV CRI /session Happy Path", async () => {
         expect(sessionId).toBeTruthy();
 
         // Make sure authSession state is as expected
@@ -39,7 +39,7 @@ describe("Test BAV End Points", () => {
         // expect(userInfoResponse).toBe(202);
     });
 
-    it.skip("E2E BAV End Points Happy Path Journey", async () => {
+    it.skip("BAV CRI /authorization Happy Path", async () => {
         expect(sessionId).toBeTruthy();
       
         // Authorization
@@ -66,8 +66,7 @@ describe("Test BAV End Points", () => {
     });
 
 
-    it.skip("Happy Path /authorisation endpoint - Repeated request made", async () => {
-        // verifyAccount endpoint
+    it.skip("BAV CRI /authorization - Repeated request made", async () => {
         const origSessionId = sessionId;
         const authResponse = await authorizationGet(sessionId);
         const authCode = authResponse.data.authorizationCode;

--- a/src/tests/api/BavUnhappyPath.test.ts
+++ b/src/tests/api/BavUnhappyPath.test.ts
@@ -1,6 +1,8 @@
 import bavStubPayload from "../data/exampleStubPayload.json";
 import {
+    authorizationGet,
     sessionPost,
+    startStubServiceAndReturnSessionId,
     stubStartPost
 } from "../utils/ApiTestSteps";
 
@@ -10,17 +12,32 @@ describe("/session Unhappy Path", () => {
         stubResponse = await stubStartPost(bavStubPayload);
     });
 
-    it("E2E Unhappy Path Journey - Invalid Request", async () => {
+    it.skip("E2E Unhappy Path Journey - Invalid Request", async () => {
         const sessionResponse = await sessionPost(stubResponse.data.clientId, "");
 
         expect(sessionResponse.status).toBe(401);
         expect(sessionResponse.data).toBe("Unauthorized");
     });
 
-    it("E2E Unhappy Path Journey - Invalid ClientID", async () => {
+    it.skip("E2E Unhappy Path Journey - Invalid ClientID", async () => {
         const sessionResponse = await sessionPost("", stubResponse.data.request);
 
         expect(sessionResponse.status).toBe(400);
         expect(sessionResponse.data).toBe("Bad Request");
     });
+
+
+});
+
+describe("E2E Unhappy Path /authorisation Endpoint", () => {
+	let sessionId: any;
+	beforeEach(async () => {
+		sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
+	});
+
+	it.skip("Incorrect session state", async () => {
+		const authResponse = await authorizationGet(sessionId);
+		expect(authResponse.status).toBe(401);
+	});
+
 });

--- a/src/tests/api/BavUnhappyPath.test.ts
+++ b/src/tests/api/BavUnhappyPath.test.ts
@@ -12,14 +12,14 @@ describe("/session Unhappy Path", () => {
         stubResponse = await stubStartPost(bavStubPayload);
     });
 
-    it.skip("E2E Unhappy Path Journey - Invalid Request", async () => {
+    it("E2E Unhappy Path Journey - Invalid Request", async () => {
         const sessionResponse = await sessionPost(stubResponse.data.clientId, "");
 
         expect(sessionResponse.status).toBe(401);
         expect(sessionResponse.data).toBe("Unauthorized");
     });
 
-    it.skip("E2E Unhappy Path Journey - Invalid ClientID", async () => {
+    it("E2E Unhappy Path Journey - Invalid ClientID", async () => {
         const sessionResponse = await sessionPost("", stubResponse.data.request);
 
         expect(sessionResponse.status).toBe(400);
@@ -35,7 +35,7 @@ describe("E2E Unhappy Path /authorisation Endpoint", () => {
 		sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
 	});
 
-	it.skip("Incorrect session state", async () => {
+	it("Incorrect session state", async () => {
 		const authResponse = await authorizationGet(sessionId);
 		expect(authResponse.status).toBe(401);
 	});

--- a/src/tests/data/BAV_CRI_AUTH_CODE_ISSUED_SCHEMA.json
+++ b/src/tests/data/BAV_CRI_AUTH_CODE_ISSUED_SCHEMA.json
@@ -1,0 +1,47 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "govuk_signin_journey_id",
+                "ip_address"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "component_id"
+    ]
+}


### PR DESCRIPTION
Creation of Authorisation Happy and Unhappy Path tests for BAV API

Add Happy and Unhappy path tests to test the /authorisation end point

KIWI-1256 (https://govukverify.atlassian.net/browse/KIWI-1256)

## Checklists

### PII logging
- [ ] Verified that no PII data is being logged

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed
