### PR TITLE
KIWI-1399 adds test scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:latest
+
+RUN apt update -y && apt upgrade -y
+RUN apt install -y curl unzip
+
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=18
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
+RUN apt-get install nodejs -y
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+
+COPY . /
+WORKDIR /
+RUN chmod +x run-tests.sh
+
+RUN cd /src && npm ci
+
+ENTRYPOINT ["/run-tests.sh"]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -102,6 +102,7 @@ Mappings:
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://bav-ipv-stub-ipvstub.review-bav.dev.account.gov.uk/.well-known/jwks.json","clientId":"5C584572","redirectUri":"https://bav-ipv-stub-ipvstub.review-bav.dev.account.gov.uk/redirect?id=bav"}]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
+      TESTHARNESSURL: "https://bav-test-harness-testharness.review-bav.dev.account.gov.uk"
     build:
       ISSUER: 'https://review-bav.build.account.gov.uk'
       DNSSUFFIX: review-bav.build.account.gov.uk
@@ -110,6 +111,7 @@ Mappings:
       RESOURCETTLSECS: 1209600 # Default 14 days
       CLIENTS: '[{"jwksEndpoint":"https://bav-ipv-stub-ipvstub.review-bav.build.account.gov.uk/.well-known/jwks.json","clientId":"5C584572","redirectUri":"https://bav-ipv-stub-ipvstub.review-bav.build.account.gov.uk/redirect?id=bav"}]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
+      TESTHARNESSURL: "https://bav-test-harness-testharness.review-bav.build.account.gov.uk"
   TxMAAccounts:
     # EVENTS is used to egress to TxMA.
     dev:
@@ -1165,3 +1167,12 @@ Outputs:
       Fn::ImportValue: !Sub "${L2DynamoStackName}-session-table-key-arn"
     Export:
       Name: !Sub ${AWS::StackName}-SessionTableEncryptionKey-arn
+  BAVIPVStubExecuteURL:
+    Condition: IsNotProdLikeEnvironment
+    Description: "BAV IPV Stub"
+    Value:
+      Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubExecuteUrl'
+  BAVTestHarnessURL:
+    Condition: IsNotProdLikeEnvironment
+    Description: "BAV Test Harness"
+    Value: !FindInMap [EnvironmentVariables, !Ref Environment, TESTHARNESSURL]

--- a/run-tests-locally.sh
+++ b/run-tests-locally.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eu
+
+if [ $# -ge 1 ] && [ -n "$1" ]
+then
+    echo "Running test container against $1"
+
+    export SAM_STACK=$1 
+    export AWS_REGION="eu-west-2"
+    export TEST_REPORT_DIR="results"
+    export ENVIRONMENT="dev"
+    export DockerImageName="$SAM_STACK"_testcontainerimage
+
+    mkdir -p results # The directory on the host where the test results will be outputted.
+
+    aws cloudformation describe-stacks --stack-name "$SAM_STACK" --region "$AWS_REGION" --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
+    eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
+    awk '{ printf("CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt > docker_vars.env
+    echo TEST_REPORT_DIR="$TEST_REPORT_DIR" >> docker_vars.env
+    echo TEST_REPORT_ABSOLUTE_DIR="$TEST_REPORT_DIR" >> docker_vars.env
+    echo TEST_ENVIRONMENT="$ENVIRONMENT" >> docker_vars.env
+    echo ENVIRONMENT="$ENVIRONMENT" >> docker_vars.env
+    echo SAM_STACK_NAME="$SAM_STACK" >> docker_vars.env
+    echo AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" >> docker_vars.env
+    echo AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" >> docker_vars.env
+    echo AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" >> docker_vars.env
+
+    #clean existing container and image before creating a new one
+    echo "Removing existing containers and images for the test"
+    docker ps -a --filter "ancestor=$DockerImageName" --filter "status=exited" -q | xargs docker rm
+    docker images $DockerImageName -q |xargs docker rmi
+
+    docker build -f Dockerfile -t $DockerImageName .
+    docker run --env-file docker_vars.env -v $(pwd)/results:/results $DockerImageName
+else    
+    echo "Please ensure you've got a stack name as the first argument after ./run_tests_locally.sh..."
+    echo "E.g. ./run_tests_locally.sh bav-cri-api"
+fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+
+remove_quotes () {
+  echo "$1" | tr -d '"'
+}
+
+declare error_code
+# shellcheck disable=SC2154
+# The CFN variables seem to include quotes when used in tests these must be removed before assigning them.
+CFN_BAVBackendURL_NoQuotes=$(remove_quotes "$CFN_BAVBackendURL")
+export DEV_CRI_BAV_API_URL=$(echo ${CFN_BAVBackendURL_NoQuotes%/})
+export DEV_IPV_BAV_STUB_URL=$(remove_quotes $CFN_BAVIPVStubExecuteURL)/start
+export DEV_BAV_TEST_HARNESS_URL=$(remove_quotes "$CFN_BAVTestHarnessURL")
+export DEV_BAV_SESSION_TABLE_NAME=$(remove_quotes "$CFN_SessionTableName")
+
+cd /src; npm run test:api
+error_code=$?
+
+cp -rf results $TEST_REPORT_ABSOLUTE_DIR
+
+exit $error_code

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -17,7 +17,7 @@
         "@aws-sdk/client-sfn": "^3.408.0",
         "@aws-sdk/client-sqs": "^3.352.0",
         "@aws-sdk/client-ssm": "^3.352.0",
-        "@aws-sdk/credential-providers": "3.352.0",
+        "@aws-sdk/credential-providers": "^3.352.0",
         "@aws-sdk/lib-dynamodb": "3.150.0",
         "@aws-sdk/node-http-handler": "^3.374.0",
         "aws-xray-sdk-core": "^3.4.1",

--- a/src/package.json
+++ b/src/package.json
@@ -14,7 +14,7 @@
     "@aws-sdk/client-sfn": "^3.408.0",
     "@aws-sdk/client-sqs": "^3.352.0",
     "@aws-sdk/client-ssm": "^3.352.0",
-    "@aws-sdk/credential-providers": "3.352.0",
+    "@aws-sdk/credential-providers": "^3.352.0",
     "@aws-sdk/lib-dynamodb": "3.150.0",
     "@aws-sdk/node-http-handler": "^3.374.0",
     "aws-xray-sdk-core": "^3.4.1",

--- a/src/tests/api/BavHappyPath.test.ts
+++ b/src/tests/api/BavHappyPath.test.ts
@@ -13,7 +13,6 @@ import {
 }
 	from "../utils/ApiTestSteps";
 
-
 describe("Test BAV End Points", () => {
 	let sessionId: any;
 

--- a/src/tests/api/BavUnhappyPath.test.ts
+++ b/src/tests/api/BavUnhappyPath.test.ts
@@ -15,6 +15,7 @@ describe.skip("/token Unhappy Path - invalid session state", () => {
 		//Session Request
 		sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
 	});
+
 	it("Request to /token with invalid session state", async () => {
 		// Authorization
 		const authResponse = await authorizationGet(sessionId);

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -26,6 +26,14 @@ const awsSigv4Interceptor = aws4Interceptor({
 	credentials: customCredentialsProvider,
 });
 
+const getCreds = async (): Promise<void> => {
+	const credentials = await customCredentialsProvider.getCredentials();
+	console.log("customCredentialsProvider", credentials);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+getCreds();
+
 HARNESS_API_INSTANCE.interceptors.request.use(awsSigv4Interceptor);
 
 const xmlParser = new XMLParser();

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -212,7 +212,7 @@ export async function getDequeuedSqsMessage(prefix: string): Promise<any> {
 
 export async function validateTxMAEventData(keyList: any): Promise<any> {
 	let i: any;
-	for (i = 0; i < keyList.length; i++) {
+	for (i = 0; i < keyList?.length; i++) {
 		const getObjectResponse = await HARNESS_API_INSTANCE.get("/object/" + keyList[i], {});
 		console.log(JSON.stringify(getObjectResponse.data, null, 2));
 		let valid = true;

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -172,14 +172,14 @@ export async function getSqsEventList(folder: string, prefix: string, txmaEventS
 		keys = listObjectsParsedResponse?.ListBucketResult?.Contents;
 		keyList = [];
 
-		if (txmaEventSize == 1) {
+		if (txmaEventSize === 1) {
 			keyList.push(listObjectsParsedResponse.ListBucketResult.Contents.Key);
 		} else {
-			for (i = 0; i < keys.length; i++) {
+			for (i = 0; i < keys?.length; i++) {
 				keyList.push(listObjectsParsedResponse?.ListBucketResult?.Contents.at(i).Key);
 			}
 		}
-	} while (keys.length < txmaEventSize);
+	} while (keys?.length < txmaEventSize);
 	return keyList;
 }
 /**

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -1,3 +1,4 @@
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers"; 
 import axios, { AxiosInstance } from "axios";
 import { aws4Interceptor } from "aws4-axios";
 import { XMLParser } from "fast-xml-parser";
@@ -9,14 +10,24 @@ import { ISessionItem } from "../../models/ISessionItem";
 const API_INSTANCE = axios.create({ baseURL: constants.DEV_CRI_BAV_API_URL });
 const ajv = new Ajv({ strict: false });
 
-const HARNESS_API_INSTANCE: AxiosInstance = axios.create({ baseURL: constants.DEV_BAV_TEST_HARNESS_URL });
+const HARNESS_API_INSTANCE : AxiosInstance = axios.create({ baseURL: constants.DEV_BAV_TEST_HARNESS_URL });
+
+const customCredentialsProvider = {
+	getCredentials: fromNodeProviderChain({
+		timeout: 1000,
+		maxRetries: 0,
+	}),
+};
 const awsSigv4Interceptor = aws4Interceptor({
 	options: {
 		region: "eu-west-2",
 		service: "execute-api",
 	},
+	credentials: customCredentialsProvider,
 });
+
 HARNESS_API_INSTANCE.interceptors.request.use(awsSigv4Interceptor);
+
 const xmlParser = new XMLParser();
 
 export async function startStubServiceAndReturnSessionId(bavStubPayload: any): Promise<any> {

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -26,14 +26,6 @@ const awsSigv4Interceptor = aws4Interceptor({
 	credentials: customCredentialsProvider,
 });
 
-const getCreds = async (): Promise<void> => {
-	const credentials = await customCredentialsProvider.getCredentials();
-	console.log("customCredentialsProvider", credentials);
-};
-
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-getCreds();
-
 HARNESS_API_INSTANCE.interceptors.request.use(awsSigv4Interceptor);
 
 const xmlParser = new XMLParser();


### PR DESCRIPTION
## Proposed changes

### What changed

Adds run test scripts

### Why did it change

So that we can run the tests in the pipeline

### Screenshots

Passing locally 
<img width="305" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/f19bed63-85e2-4c02-b440-ee8556318c53">
<img width="637" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/3b894ca8-3361-4e39-9a76-a2201ff33358">


### Issue tracking
- [KIWI-1399](https://govukverify.atlassian.net/browse/KIWI-1399)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [x] Added to deployment repository
- [x] Added to local startup repository


[KIWI-1399]: https://govukverify.atlassian.net/browse/KIWI-1399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ