### PR TITLE
[KIWI-1421] updates linting script

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -19,6 +19,7 @@
         "@aws-sdk/client-ssm": "^3.352.0",
         "@aws-sdk/credential-providers": "3.352.0",
         "@aws-sdk/lib-dynamodb": "3.150.0",
+        "@aws-sdk/node-http-handler": "^3.374.0",
         "aws-xray-sdk-core": "^3.4.1",
         "axios": ">=1.3.4",
         "class-validator": "0.14.0",
@@ -645,6 +646,21 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.352.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.352.0.tgz",
@@ -689,6 +705,21 @@
         "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -742,6 +773,21 @@
         "@aws-sdk/util-utf8": "3.310.0",
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -807,6 +853,21 @@
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
         "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1353,6 +1414,21 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sqs/node_modules/fast-xml-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
@@ -1417,6 +1493,21 @@
         "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1516,6 +1607,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.352.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.352.0.tgz",
@@ -1557,6 +1678,21 @@
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
         "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2199,14 +2335,63 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.350.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
-      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "version": "3.374.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.374.0.tgz",
+      "integrity": "sha512-v1Z6m0wwkf65/tKuhwrtPRqVoOtNkDTRn2MBMtxCwEw+8V8Q+YRFqVgGN+J1n53ktE0G5OYVBux/NHiAjJHReQ==",
+      "deprecated": "This package has moved to @smithy/node-http-handler",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.347.0",
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/querystring-builder": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
+        "@smithy/node-http-handler": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/node-http-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+      "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^1.1.0",
+        "@smithy/protocol-http": "^1.2.0",
+        "@smithy/querystring-builder": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/querystring-builder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+      "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-uri-escape": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/util-uri-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2555,6 +2740,21 @@
         "@aws-sdk/node-http-handler": "3.350.0",
         "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4272,11 +4472,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
       "dependencies": {
-        "@smithy/types": "^1.0.0",
+        "@smithy/types": "^1.2.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4416,9 +4616,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -11642,6 +11842,20 @@
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/client-dynamodb": {
@@ -11690,6 +11904,18 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -11738,6 +11964,20 @@
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/client-s3": {
@@ -11802,6 +12042,18 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        },
         "fast-xml-parser": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
@@ -12246,6 +12498,18 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        },
         "fast-xml-parser": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
@@ -12301,6 +12565,18 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -12346,6 +12622,20 @@
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso-oidc": {
@@ -12386,6 +12676,20 @@
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/client-sts": {
@@ -12432,6 +12736,18 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        },
         "fast-xml-parser": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
@@ -12934,15 +13250,53 @@
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.350.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
-      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "version": "3.374.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.374.0.tgz",
+      "integrity": "sha512-v1Z6m0wwkf65/tKuhwrtPRqVoOtNkDTRn2MBMtxCwEw+8V8Q+YRFqVgGN+J1n53ktE0G5OYVBux/NHiAjJHReQ==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.347.0",
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/querystring-builder": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
+        "@smithy/node-http-handler": "^1.0.2",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+          "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+          "requires": {
+            "@smithy/abort-controller": "^1.1.0",
+            "@smithy/protocol-http": "^1.2.0",
+            "@smithy/querystring-builder": "^1.1.0",
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+          "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "@smithy/util-uri-escape": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/property-provider": {
@@ -13208,6 +13562,20 @@
         "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-buffer-from": "3.310.0",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/node-http-handler": {
+          "version": "3.350.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+          "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.347.0",
+            "@aws-sdk/protocol-http": "3.347.0",
+            "@aws-sdk/querystring-builder": "3.347.0",
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/util-uri-escape": {
@@ -14563,11 +14931,11 @@
       }
     },
     "@smithy/protocol-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
       "requires": {
-        "@smithy/types": "^1.0.0",
+        "@smithy/types": "^1.2.0",
         "tslib": "^2.5.0"
       }
     },
@@ -14681,9 +15049,9 @@
       }
     },
     "@smithy/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
       "requires": {
         "tslib": "^2.5.0"
       }

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-ssm": "^3.352.0",
     "@aws-sdk/credential-providers": "3.352.0",
     "@aws-sdk/lib-dynamodb": "3.150.0",
+    "@aws-sdk/node-http-handler": "^3.374.0",
     "aws-xray-sdk-core": "^3.4.1",
     "axios": ">=1.3.4",
     "class-validator": "0.14.0",
@@ -31,7 +32,7 @@
     "test:unit": "npm run compile && npm run unit",
     "lint:fix": "eslint --fix --output-file ./reports/eslint/report.html --format html -c .eslintrc.js --ext .ts .",
     "compile": "./node_modules/.bin/tsc",
-    "lint": "eslint --output-file ./reports/eslint/reportFile.html --format html -c .eslintrc.js --ext .ts",
+    "lint": "eslint **/**.ts **/**.test.ts",
     "test:infra": "./node_modules/.bin/jest --testMatch '**/infra/?(*.)test.ts' ",
     "api": "JEST_JUNIT_OUTPUT_NAME=api-report.xml ./node_modules/.bin/jest --runInBand --testPathPattern=tests/api/",
     "test:api": "npm run compile && npm run api"

--- a/src/services/AccessTokenRequestProcessor.ts
+++ b/src/services/AccessTokenRequestProcessor.ts
@@ -4,7 +4,6 @@ import { KmsJwtAdapter } from "../utils/KmsJwtAdapter";
 import { createDynamoDbClient } from "../utils/DynamoDBFactory";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { Response } from "../utils/Response";
-import { ISessionItem } from "../models/ISessionItem";
 import { absoluteTimeNow } from "../utils/DateTimeUtils";
 import { Constants, EnvironmentVariables } from "../utils/Constants";
 import { MessageCodes } from "../models/enums/MessageCodes";
@@ -49,7 +48,7 @@ export class AccessTokenRequestProcessor {
 		return AccessTokenRequestProcessor.instance;
 	}
 
-	async processRequest(event: APIGatewayProxyEvent): Promise<Response> {		
+	async processRequest(event: APIGatewayProxyEvent): Promise<Response> {
 		try {
 			let requestPayload;
 			try {

--- a/src/tests/api/BavHappyPath.test.ts
+++ b/src/tests/api/BavHappyPath.test.ts
@@ -1,86 +1,88 @@
 import bavStubPayload from "../data/exampleStubPayload.json";
 import { constants } from "../utils/ApiConstants";
 import {
-    authorizationGet,
-    getSessionAndVerifyKey,
-    getSessionAndVerifyKeyExists,
-    getSqsEventList,
-    startStubServiceAndReturnSessionId,
-    tokenPost,
-    validateTxMAEventData,
-    validateWellKnownResponse,
-    wellKnownGet
+	authorizationGet,
+	getSessionAndVerifyKey,
+	getSessionAndVerifyKeyExists,
+	getSqsEventList,
+	startStubServiceAndReturnSessionId,
+	tokenPost,
+	validateTxMAEventData,
+	validateWellKnownResponse,
+	wellKnownGet,
 }
-    from "../utils/ApiTestSteps";
+	from "../utils/ApiTestSteps";
 
 
 describe("Test BAV End Points", () => {
-    let sessionId: any;
+	let sessionId: any;
 
-    beforeEach(async () => {
-        //Session Request
-        sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
-    });
+	beforeEach(async () => {
+		//Session Request
+		sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
+	});
 
-    it("BAV CRI /session Happy Path", async () => {
-        expect(sessionId).toBeTruthy();
+	it("BAV CRI /session Happy Path", async () => {
+		expect(sessionId).toBeTruthy();
 
-        // Make sure authSession state is as expected
-        await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_SESSION_CREATED");
+		// Make sure authSession state is as expected
+		await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_SESSION_CREATED");
 
-        // Make sure txma event is present & valid
-        const sqsMessage = await getSqsEventList("txma/", sessionId, 1);
-        await validateTxMAEventData(sqsMessage);
-    });
+		// Make sure txma event is present & valid
+		const sqsMessage = await getSqsEventList("txma/", sessionId, 1);
+		await validateTxMAEventData(sqsMessage);
+	});
 
-    it.skip("BAV CRI /authorization Happy Path", async () => {
-        expect(sessionId).toBeTruthy();
+	// eslint-disable-next-line @typescript-eslint/tslint/config
+	it.skip("BAV CRI /authorization Happy Path", async () => {
+		expect(sessionId).toBeTruthy();
 
-        // Authorization
-        const authResponse = await authorizationGet(sessionId);
-        expect(authResponse.status).toBe(200);
-        expect(authResponse.data.authorizationCode).toBeTruthy();
-        expect(authResponse.data.redirect_uri).toBeTruthy();
-        expect(authResponse.data.state).toBeTruthy();
+		// Authorization
+		const authResponse = await authorizationGet(sessionId);
+		expect(authResponse.status).toBe(200);
+		expect(authResponse.data.authorizationCode).toBeTruthy();
+		expect(authResponse.data.redirect_uri).toBeTruthy();
+		expect(authResponse.data.state).toBeTruthy();
 
-        // Make sure authSession state is as expected
-        await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_AUTH_CODE_ISSUED");
+		// Make sure authSession state is as expected
+		await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_AUTH_CODE_ISSUED");
 
-        // Make sure txma event is present & valid
-        const sqsMessage = await getSqsEventList("txma/", sessionId, 2);
-        await validateTxMAEventData(sqsMessage);
-    });
+		// Make sure txma event is present & valid
+		const sqsMessage = await getSqsEventList("txma/", sessionId, 2);
+		await validateTxMAEventData(sqsMessage);
+	});
 
+	// eslint-disable-next-line @typescript-eslint/tslint/config
+	it.skip("BAV CRI /authorization - Repeated request made", async () => {
+		const origSessionId = sessionId;
+		const authResponse = await authorizationGet(sessionId);
+		const authCode = authResponse.data.authorizationCode;
+		const authRepeatResponse = await authorizationGet(origSessionId);
+		const authRepeatResponseCode = authRepeatResponse.data.authorizationCode;
+		expect(authCode).not.toEqual(authRepeatResponseCode);
+	});
 
-    it.skip("BAV CRI /authorization - Repeated request made", async () => {
-        const origSessionId = sessionId;
-        const authResponse = await authorizationGet(sessionId);
-        const authCode = authResponse.data.authorizationCode;
-        const authRepeatResponse = await authorizationGet(origSessionId);
-        const authRepeatResponseCode = authRepeatResponse.data.authorizationCode;
-        expect(authCode).not.toEqual(authRepeatResponseCode);
-    });
+	// eslint-disable-next-line @typescript-eslint/tslint/config
+	it.skip("BAV CRI /token Happy Path", async () => {
+		const authResponse = await authorizationGet(sessionId);
 
-    it.skip("BAV CRI /token Happy Path", async () => {
-        const authResponse = await authorizationGet(sessionId);
+		// Token
+		const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri);
+		expect(tokenResponse.status).toBe(200);
 
-        // Token
-        const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri);
-        expect(tokenResponse.status).toBe(200);
+		// Verify access token expiry date exists
+		await getSessionAndVerifyKeyExists(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "accessTokenExpiryDate");
 
-        // Verify access token expiry date exists
-        await getSessionAndVerifyKeyExists(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "accessTokenExpiryDate");
-
-        // Check session state
-        await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_ACCESS_TOKEN_ISSUED");
-    });
+		// Check session state
+		await getSessionAndVerifyKey(sessionId, constants.DEV_BAV_SESSION_TABLE_NAME, "authSessionState", "BAV_ACCESS_TOKEN_ISSUED");
+	});
 });
 
 describe("E2E Happy Path Well Known Endpoint", () => {
-    it("E2E Happy Path Journey - Well Known", async () => {
-        // Well Known
-        const wellKnownResponse = await wellKnownGet();
-        validateWellKnownResponse(wellKnownResponse.data);
-        expect(wellKnownResponse.status).toBe(200);
-    });
+	it("E2E Happy Path Journey - Well Known", async () => {
+		// Well Known
+		const wellKnownResponse = await wellKnownGet();
+		validateWellKnownResponse(wellKnownResponse.data);
+		expect(wellKnownResponse.status).toBe(200);
+	});
 });

--- a/src/tests/api/BavUnhappyPath.test.ts
+++ b/src/tests/api/BavUnhappyPath.test.ts
@@ -1,52 +1,52 @@
 import bavStubPayload from "../data/exampleStubPayload.json";
 import {
-    authorizationGet,
-    sessionPost,
-    startStubServiceAndReturnSessionId,
-    stubStartPost,
-    tokenPost
+	authorizationGet,
+	sessionPost,
+	startStubServiceAndReturnSessionId,
+	stubStartPost,
+	tokenPost,
 } from "../utils/ApiTestSteps";
 
-
+// eslint-disable-next-line @typescript-eslint/tslint/config
 describe.skip("/token Unhappy Path - invalid session state", () => {
-    let sessionId: any;
+	let sessionId: any;
 
-    beforeEach(async () => {
-        //Session Request
-        sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
-    });
-    it("Request to /token with invalid session state", async () => {
-        // Authorization
-        const authResponse = await authorizationGet(sessionId);
+	beforeEach(async () => {
+		//Session Request
+		sessionId = await startStubServiceAndReturnSessionId(bavStubPayload);
+	});
+	it("Request to /token with invalid session state", async () => {
+		// Authorization
+		const authResponse = await authorizationGet(sessionId);
 
-        // Token
-        await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri);
+		// Token
+		await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri);
 
-        // Request to /token endpoing again (which now has an invalid session state)
-        const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri);
-        expect(tokenResponse.status).toBe(401);
-    });
+		// Request to /token endpoing again (which now has an invalid session state)
+		const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri);
+		expect(tokenResponse.status).toBe(401);
+	});
 });
 
 describe("/session Unhappy Path", () => {
-    let stubResponse: any;
-    beforeEach(async () => {
-        stubResponse = await stubStartPost(bavStubPayload);
-    });
+	let stubResponse: any;
+	beforeEach(async () => {
+		stubResponse = await stubStartPost(bavStubPayload);
+	});
 
-    it("E2E Unhappy Path Journey - Invalid Request", async () => {
-        const sessionResponse = await sessionPost(stubResponse.data.clientId, "");
+	it("E2E Unhappy Path Journey - Invalid Request", async () => {
+		const sessionResponse = await sessionPost(stubResponse.data.clientId, "");
 
-        expect(sessionResponse.status).toBe(401);
-        expect(sessionResponse.data).toBe("Unauthorized");
-    });
+		expect(sessionResponse.status).toBe(401);
+		expect(sessionResponse.data).toBe("Unauthorized");
+	});
 
-    it("E2E Unhappy Path Journey - Invalid ClientID", async () => {
-        const sessionResponse = await sessionPost("", stubResponse.data.request);
+	it("E2E Unhappy Path Journey - Invalid ClientID", async () => {
+		const sessionResponse = await sessionPost("", stubResponse.data.request);
 
-        expect(sessionResponse.status).toBe(400);
-        expect(sessionResponse.data).toBe("Bad Request");
-    });
+		expect(sessionResponse.status).toBe(400);
+		expect(sessionResponse.data).toBe("Bad Request");
+	});
 
 
 });

--- a/src/tests/unit/JwksHandler.test.ts
+++ b/src/tests/unit/JwksHandler.test.ts
@@ -182,7 +182,3 @@ describe("JwksHandler", () => {
 		});
 	});
 });
-function async(): (...args: string[]) => any {
-	throw new Error("Function not implemented.");
-}
-

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -47,7 +47,12 @@ export interface TxmaEvent extends BaseTxmaEvent {
 	"extensions"?: ExtensionObject;
 }
 
-export const buildCoreEventFields = (session: ISessionItem, issuer: string, sourceIp?: string | undefined, getNow: () => number = absoluteTimeNow): BaseTxmaEvent => {
+export const buildCoreEventFields = (
+	session: ISessionItem,
+	issuer: string,
+	sourceIp?: string | undefined,
+	getNow: () => number = absoluteTimeNow,
+): BaseTxmaEvent => {
 	return {
 		user: {
 			user_id: session.subject,


### PR DESCRIPTION
## Proposed changes

### What changed

Updates the lint script so that the PR pipeline fails if there are linting errors

Addresses linting errors.

### Why did it change

To catch linting errors in PRs before they are merged

### Screenshots

With linting error present
<img width="1789" alt="Screenshot 2023-11-03 at 10 30 24 am" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/87bd2377-c836-4ed1-8909-7027dd0d0f05">

With only warnings present 
<img width="1766" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/3624a2a5-3883-43c0-bcaa-c19ef3bd50e7">


### Issue tracking

- [KIWI-1421](https://govukverify.atlassian.net/browse/KIWI-1421)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[KIWI-1421]: https://govukverify.atlassian.net/browse/KIWI-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ