### PR TITLE
KIWI-1375: Updates proxy to use HMRC mock

### DIFF
--- a/infra-l2-outbound-proxy/src/tests/infra/infra.test.ts
+++ b/infra-l2-outbound-proxy/src/tests/infra/infra.test.ts
@@ -10,8 +10,8 @@ it("Should contain only one Api Gateway V2 resource definition", () => {
 describe("Outbound Proxy Api Gateway Integration URLs", () => {
   test.each`
     ENVIRONMENT      | HMRCURL                                              | PRETTYPROXYURL
-    ${"dev"}         | ${"https://api.isc.externaltest.tax.service.gov.uk"} | ${"proxy.review-bav.dev.account.gov.uk"}
-    ${"build"}       | ${"https://api.isc.externaltest.tax.service.gov.uk"} | ${"proxy.review-bav.build.account.gov.uk"}
+    ${"dev"}         | ${"https://szxkgvdy5j.execute-api.eu-west-2.amazonaws.com/dev"} | ${"proxy.review-bav.dev.account.gov.uk"}
+    ${"build"}       | ${"https://kcdflis5zl.execute-api.eu-west-2.amazonaws.com/build"} | ${"proxy.review-bav.build.account.gov.uk"}
     ${"staging"}     | ${"https://api.isc.externaltest.tax.service.gov.uk"} | ${"proxy.review-bav.staging.account.gov.uk"}
     ${"integration"} | ${"https://api.isc.externaltest.tax.service.gov.uk"} | ${"proxy.review-bav.integration.account.gov.uk"}
     ${"production"}  | ${"https://api.isc.production.tax.service.gov.uk"} | ${"proxy.review-bav.account.gov.uk"}

--- a/infra-l2-outbound-proxy/template.yaml
+++ b/infra-l2-outbound-proxy/template.yaml
@@ -15,10 +15,10 @@ Conditions:
 Mappings:
   EnvironmentVariables:
     dev:
-      HMRCURL: "https://api.isc.externaltest.tax.service.gov.uk"
+      HMRCURL: "https://szxkgvdy5j.execute-api.eu-west-2.amazonaws.com/dev"
       PRETTYPROXYURL: "proxy.review-bav.dev.account.gov.uk"
     build:
-      HMRCURL: "https://api.isc.externaltest.tax.service.gov.uk"
+      HMRCURL: "https://kcdflis5zl.execute-api.eu-west-2.amazonaws.com/build"
       PRETTYPROXYURL: "proxy.review-bav.build.account.gov.uk"
     staging:
       HMRCURL: "https://api.isc.externaltest.tax.service.gov.uk"


### PR DESCRIPTION
## Proposed changes

### What changed

Updates proxy to use mock

### Why did it change

To use the HMRC mock in dev and build

### Issue tracking
- [KIWI-1375](https://govukverify.atlassian.net/browse/KIWI-1375)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[KIWI-1375]: https://govukverify.atlassian.net/browse/KIWI-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ