### PR TITLE
KIWI-1507: Updates name that stub returns

### DIFF
--- a/bav-ipv-stub/src/handlers/startBavCheck.ts
+++ b/bav-ipv-stub/src/handlers/startBavCheck.ts
@@ -29,15 +29,11 @@ export const handler = async (
       {
         nameParts: [
           {
-            value: "Frederick",
+            value: "Yasmine",
             type: "GivenName",
           },
           {
-            value: "Joseph",
-            type: "GivenName",
-          },
-          {
-            value: "Flintstone",
+            value: "Young",
             type: "FamilyName",
           },
         ],


### PR DESCRIPTION
## Proposed changes

### What changed

Updates name that stub returns

### Why did it change

To trigger success response from HMRC mock

### Screenshots

<img width="1182" alt="Screenshot 2023-12-12 at 15 27 38" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/eef2de65-7930-453f-a79c-90bccb9460f6">


### Issue tracking

- [KIWI-1507](https://govukverify.atlassian.net/browse/KIWI-1507)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
