### PR TITLE
KIWI-1524: implements obfuscateJSONValues

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -232,23 +232,23 @@
         "filename": "src/utils/Constants.ts",
         "hashed_secret": "727250308c598963edbd5e9439e03665fbd4549e",
         "is_verified": false,
-        "line_number": 91
+        "line_number": 93
       },
       {
         "type": "Secret Keyword",
         "filename": "src/utils/Constants.ts",
         "hashed_secret": "ae1144eb948716db5b55a98d9ef49b01f9d10729",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 95
       },
       {
         "type": "Secret Keyword",
         "filename": "src/utils/Constants.ts",
         "hashed_secret": "c88b28ecd63faa469cf84bdfae92a095b72451d7",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 99
       }
     ]
   },
-  "generated_at": "2024-01-10T11:23:13Z"
+  "generated_at": "2024-01-11T14:38:10Z"
 }

--- a/src/models/PersonIdentityItem.ts
+++ b/src/models/PersonIdentityItem.ts
@@ -7,9 +7,6 @@ export interface PersonIdentityName {
 	nameParts: PersonIdentityNamePart[];
 }
 
-export interface PersonIdentityDateOfBirth {
-	value: string;
-}
 
 export interface PersonIdentityItem {
 	sessionId: string;

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -73,6 +73,8 @@ export class Constants {
   static readonly HMRC_USER_AGENT = "one-login-bav-cri";
   
   static readonly MAX_RETRIES = 2;
+
+  static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "session_id", "govuk_signin_journey_id", "attemptNum"];
 }
 
 export const EnvironmentVariables = {


### PR DESCRIPTION
## Proposed changes

### What changed

 implements obfuscateJSONValues and logs events sent to TxMA

### Why did it change

To help production debugging

### Screenshots

<img width="1416" alt="Screenshot 2024-01-05 at 3 29 06 pm" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/156541e7-cead-445a-b8d6-2965ec8ad87b">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1524](https://govukverify.atlassian.net/browse/KIWI-1524

## Checklists

### PII logging

- [X] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[KIWI-1524]: https://govukverify.atlassian.net/browse/KIWI-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ