### PR TITLE
Allow one attempt and one retry

### DIFF
--- a/src/models/ISessionItem.ts
+++ b/src/models/ISessionItem.ts
@@ -27,7 +27,6 @@ export interface ISessionItem extends IBAVSession {
 	subject: string;
 	persistentSessionId: string;
 	clientIpAddress: string;
-	attemptCount: number;
 	authSessionState: string;
 	evidence_requested?: EvidenceRequested;
 	copCheckResult?: CopCheckResult;

--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -178,7 +178,6 @@ export class SessionRequestProcessor {
   		subject: jwtPayload.sub ? jwtPayload.sub : "",
   		persistentSessionId: jwtPayload.persistent_session_id,
   		clientIpAddress,
-  		attemptCount: 0,
   		authSessionState: AuthSessionState.BAV_SESSION_CREATED,
   		evidence_requested: jwtPayload.evidence_requested,
   	};

--- a/src/services/UserInfoRequestProcessor.ts
+++ b/src/services/UserInfoRequestProcessor.ts
@@ -99,7 +99,6 @@ export class UserInfoRequestProcessor {
 			session: {
 				authSessionState: session.authSessionState,
 				accessTokenExpiryDate: session.accessTokenExpiryDate,
-				attemptCount: session.attemptCount,
 				authorizationCodeExpiryDate: session.authorizationCodeExpiryDate,
 				createdDate: session.createdDate,
 				expiryDate: session.expiryDate,

--- a/src/tests/api/BavHappyPath.test.ts
+++ b/src/tests/api/BavHappyPath.test.ts
@@ -123,12 +123,6 @@ describe("BAV CRI: /verify-account Retry Happy Path Tests", () => {
 		expect(verifyAccountResponse.data.message).toBe("Success");
 		expect(verifyAccountResponse.data.retryCount).toBe(1);
 
-		// Verify-account second name mismatch
-		const verifyAccountResponseRetry = await verifyAccountPost(verifyAccountYesPayload, sessionId);
-		expect(verifyAccountResponseRetry.status).toBe(200);
-		expect(verifyAccountResponseRetry.data.message).toBe("Success");
-		expect(verifyAccountResponseRetry.data.retryCount).toBe(2);
-
 		// Make sure txma event is present & valid
 		const sqsMessage = await getSqsEventList("txma/", sessionId, 3);
 		await validateTxMAEventData(sqsMessage);

--- a/src/tests/unit/services/AbortRequestProcessor.test.ts
+++ b/src/tests/unit/services/AbortRequestProcessor.test.ts
@@ -31,7 +31,6 @@ const session: ISessionItem = {
 	subject: "sub",
 	persistentSessionId: "sdgsdg",
 	clientIpAddress: "127.0.0.1",
-	attemptCount: 1,
 	authSessionState: AuthSessionState.BAV_DATA_RECEIVED,
 };
 

--- a/src/tests/unit/services/AccessTokenRequestProcessor.test.ts
+++ b/src/tests/unit/services/AccessTokenRequestProcessor.test.ts
@@ -44,7 +44,6 @@ function getMockSessionItem(): ISessionItem {
 		subject: "sub",
 		persistentSessionId: "sdgsdg",
 		clientIpAddress: "127.0.0.1",
-		attemptCount: 1,
 		authSessionState: AuthSessionState.BAV_AUTH_CODE_ISSUED,
 	};
 	return sess;

--- a/src/tests/unit/services/AuthorizationRequestProcessor.test.ts
+++ b/src/tests/unit/services/AuthorizationRequestProcessor.test.ts
@@ -28,7 +28,6 @@ const session: ISessionItem = {
 	subject: "sub",
 	persistentSessionId: "sdgsdg",
 	clientIpAddress: "127.0.0.1",
-	attemptCount: 1,
 	authSessionState: AuthSessionState.BAV_DATA_RECEIVED,
 };
 const authResponse = {

--- a/src/tests/unit/services/UserInfoRequestProcessor.test.ts
+++ b/src/tests/unit/services/UserInfoRequestProcessor.test.ts
@@ -43,7 +43,6 @@ function getMockSessionItem(): ISessionItem {
 		subject: "sub",
 		persistentSessionId: "sdgsdg",
 		clientIpAddress: "127.0.0.1",
-		attemptCount: 1,
 		authSessionState: "BAV_ACCESS_TOKEN_ISSUED",
 		copCheckResult: "FULL_MATCH",
 		retryCount: 1,

--- a/src/tests/unit/services/VerifiableCredentialService.test.ts
+++ b/src/tests/unit/services/VerifiableCredentialService.test.ts
@@ -29,7 +29,6 @@ function getMockSessionItem(): ISessionItem {
 		subject: "sub",
 		persistentSessionId: "sdgsdg",
 		clientIpAddress: "127.0.0.1",
-		attemptCount: 1,
 		authSessionState: "BAV_ACCESS_TOKEN_ISSUED",
 		copCheckResult: "FULL_MATCH",
 		hmrcUuid: "testId",

--- a/src/tests/unit/services/VerifyAccountRequestProcessor.test.ts
+++ b/src/tests/unit/services/VerifyAccountRequestProcessor.test.ts
@@ -211,14 +211,14 @@ describe("VerifyAccountRequestProcessor", () => {
 
 		it("saves saveCopCheckResult with increased retryCount if there was no match", async () => {
 			mockBavService.getPersonIdentityById.mockResolvedValueOnce(person);
-			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, retryCount: 1 });
+			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, retryCount: 0 });
 			mockHmrcService.verify.mockResolvedValueOnce({ ...hmrcVerifyResponse, nameMatches: "partial" });
 
 			const response = await verifyAccountRequestProcessorTest.processRequest(sessionId, body, clientIpAddress);
 
-			expect(mockBavService.saveCopCheckResult).toHaveBeenCalledWith(sessionId, CopCheckResults.PARTIAL_MATCH, 2);
+			expect(mockBavService.saveCopCheckResult).toHaveBeenCalledWith(sessionId, CopCheckResults.PARTIAL_MATCH, 1);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
-			expect(response.body).toBe(JSON.stringify({ message:"Success", retryCount: 2 }));
+			expect(response.body).toBe(JSON.stringify({ message:"Success", retryCount: 1 }));
 		});
 
 		it("returns error response if cop check result is MATCH_ERROR", async () => {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -72,7 +72,7 @@ export class Constants {
 
   static readonly HMRC_USER_AGENT = "one-login-bav-cri";
   
-  static readonly MAX_RETRIES = 2;
+  static readonly MAX_RETRIES = 1;
 
   static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "session_id", "govuk_signin_journey_id", "attemptNum"];
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Reduce max retries to 1 - to allow one attempt and one retry
- Removes `attemptCount` as it has been replaced by `retryCount` and isn't being used

### Why did it change

Requirement was incorrectly implemented

### Screenshots

First attempt fails
![image](https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/92384530-b5c6-4149-89b8-9f175c929472)

First retry fails
![image](https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/4fa02abe-304f-43c1-a882-236d63998ae5)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1416](https://govukverify.atlassian.net/browse/KIWI-1416)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[KIWI-1416]: https://govukverify.atlassian.net/browse/KIWI-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ