### PR TITLE
[KIWI-1564]Remove the error object from the error log when HMRCToken endpoint errors out

### DIFF
--- a/src/services/HmrcService.ts
+++ b/src/services/HmrcService.ts
@@ -112,7 +112,7 @@ export class HmrcService {
     			this.logger.info("Received response from HMRC token endpoint");
     			return data;
     		} catch (error: any) {
-    			this.logger.error({ message: "An error occurred when generating HMRC token", error, messageCode: MessageCodes.FAILED_GENERATING_HMRC_TOKEN });
+    			this.logger.error({ message: "An error occurred when generating HMRC token", statusCode: error?.response?.status, messageCode: MessageCodes.FAILED_GENERATING_HMRC_TOKEN });
 
     			if (error?.response?.status === 500 && retryCount < this.maxRetries) {
     				this.logger.error(`generateToken - Retrying to generate hmrcToken. Sleeping for ${this.backoffPeriodMs} ms ${HmrcService.name} ${new Date().toISOString()}`, { retryCount });

--- a/src/tests/unit/services/HmrcService.test.ts
+++ b/src/tests/unit/services/HmrcService.test.ts
@@ -194,7 +194,7 @@ describe("HMRC Service", () => {
 				new AppError(HttpCodesEnum.SERVER_ERROR, "Error generating HMRC token"),
 			);
 			expect(logger.error).toHaveBeenCalledWith(
-				{ message: "An error occurred when generating HMRC token", error, messageCode: MessageCodes.FAILED_GENERATING_HMRC_TOKEN },
+				{ message: "An error occurred when generating HMRC token", statusCode: 400, messageCode: MessageCodes.FAILED_GENERATING_HMRC_TOKEN },
 			);
 			expect(axios.post).toHaveBeenCalledTimes(1);
 			expect(axios.post).toHaveBeenCalledWith(`${hmrcBaseUrl}${Constants.HMRC_TOKEN_ENDPOINT_PATH}`, expectedParams, config);
@@ -212,7 +212,7 @@ describe("HMRC Service", () => {
 				new AppError(HttpCodesEnum.SERVER_ERROR, "Error generating HMRC token"),
 			);
 			expect(logger.error).toHaveBeenCalledWith(
-				{ message: "An error occurred when generating HMRC token", error, messageCode: MessageCodes.FAILED_GENERATING_HMRC_TOKEN },
+				{ message: "An error occurred when generating HMRC token", statusCode: 500, messageCode: MessageCodes.FAILED_GENERATING_HMRC_TOKEN },
 			);
 			expect(axios.post).toHaveBeenCalledTimes(4);
 			expect(axios.post).toHaveBeenCalledWith(`${hmrcBaseUrl}${Constants.HMRC_TOKEN_ENDPOINT_PATH}`,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

error log was displaying the error object which may contain clientId 
Evidence attached to the ticket for reference.

### Why did it change

Identified as part of recent incident. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1564](https://govukverify.atlassian.net/browse/KIWI-1564)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged



[KIWI-1564]: https://govukverify.atlassian.net/browse/KIWI-1564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ