### PR TITLE
KIWI 1533: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/src'
+    schedule:
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+    - dependabot
+    ignore:
+      - dependency-name: "node"
+        versions: ["17.x","18.x"]
+    commit-message:
+      prefix: BAU
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    target-branch: main
+    labels:
+    - dependabot

--- a/.github/workflows/pull-request-sonar.yml
+++ b/.github/workflows/pull-request-sonar.yml
@@ -32,9 +32,8 @@ jobs:
       - name: Test and coverage
         run: npm run test:unit -- --coverage
       - name: "Run SonarCloud Scan"
-        if: ${{ success() }}
+        if: ${{ success() && github.actor != 'dependabot[bot]' }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
### What changed

- Added the dependabot workflow to the BAV BE repository
- Updated the PR sonar workflow to exclude dependabot

### Why did it change

Dependabot is an automated tool that helps manage dependencies and keep them up to date. This is recommended by the [identity team manual](https://team-manual.account.gov.uk/development-standards-processes/dependabot/). Configuration of the tool in BAV API workflows was missed during the initial repository setup so is added as part of this ticket.

### Issue tracking
- [KIWI-1533](https://govukverify.atlassian.net/browse/KIWI-1533)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
