### PR TITLE
KIWI-1674: pii check automation

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,4 +20,10 @@ error_code=$?
 
 cp -rf results $TEST_REPORT_ABSOLUTE_DIR
 
+sleep 2m
+
+apt-get install jq -y
+cd /src; npm run test:pii
+error_code=$?
+
 exit $error_code

--- a/src/check-logs.sh
+++ b/src/check-logs.sh
@@ -8,7 +8,7 @@ query="fields @timestamp, @message, @logStream, @log | filter @message like \"$f
 
 echo $query
 
-stack_name="bav-cri-api-1674"
+stack_name="bav-cri-api"
 log_groups=(
     "/aws/lambda/BAV-Authorization-$stack_name"
     "/aws/lambda/BAV-person-info-$stack_name"

--- a/src/check-logs.sh
+++ b/src/check-logs.sh
@@ -8,7 +8,7 @@ query="fields @timestamp, @message, @logStream, @log | filter @message like \"$f
 
 echo $query
 
-stack_name="bav-cri-api"
+stack_name="bav-cri-api-1674"
 log_groups=(
     "/aws/lambda/BAV-Authorization-$stack_name"
     "/aws/lambda/BAV-person-info-$stack_name"

--- a/src/check-logs.sh
+++ b/src/check-logs.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+test_data="./tests/data/exampleStubPayload.json"
+firstName=$(jq -r '.shared_claims.name[0].nameParts[0].value' "$test_data")
+lastName=$(jq -r '.shared_claims.name[0].nameParts[1].value' "$test_data")
+
+query="fields @timestamp, @message, @logStream, @log | filter @message like \"$firstName\" or @message like \"$lastName\""
+
+echo $query
+
+stack_name="bav-cri-api"
+log_groups=(
+    "/aws/lambda/BAV-Authorization-$stack_name"
+    "/aws/lambda/BAV-person-info-$stack_name"
+    "/aws/lambda/Access-Token-$stack_name"
+    "/aws/lambda/BAV-Session-$stack_name"
+    "/aws/lambda/BAV-verify-account-$stack_name"
+    "/aws/lambda/BAV-Abort-$stack_name"
+    "/aws/lambda/BAV-UserInfo-$stack_name"
+)
+
+current_epoch=$(date +%s)
+fifteen_mins_ago_epoch=$((current_epoch - (15 * 60)))
+
+start_time=$fifteen_mins_ago_epoch
+end_time=$current_epoch
+
+query_id=$(aws logs start-query \
+    --log-group-names "${log_groups[@]}" \
+    --start-time "$start_time" \
+    --end-time "$end_time" \
+    --query-string "$query" \
+    --output text --query 'queryId')
+
+status="Running"
+while [ "$status" = "Running" ]; do
+    echo "Waiting for query to complete..."
+    sleep 1
+    query_status=$(aws logs get-query-results --query-id "$query_id")
+    status=$(echo "$query_status" | grep -o '"status": "[^"]*"' | cut -d '"' -f 4)
+done
+
+if echo "$query_status" | grep -q '"results": \[\]'; then
+    echo "Query found no PII 🎉"
+    exit 0
+else
+    echo "Query returned results:"
+    echo "$query_status" | jq -r '.results[] | @json'
+    exit 1
+fi

--- a/src/package.json
+++ b/src/package.json
@@ -37,7 +37,8 @@
     "lint": "eslint --ext .ts .",
     "test:infra": "./node_modules/.bin/jest --testMatch '**/infra/?(*.)test.ts' ",
     "api": "JEST_JUNIT_OUTPUT_NAME=api-report.xml ./node_modules/.bin/jest --runInBand --testPathPattern=tests/api/",
-    "test:api": "npm run compile && npm run api"
+    "test:api": "npm run compile && npm run api",
+    "test:pii": "bash ./check-logs.sh"
   },
   "devDependencies": {
     "@aws-cdk/assertions": "^1.172.0",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds check-logs script that scans logs for PII that is used in automation testing

### Why did it change

To catch PII in our dev deploy workflows

### Screenshots

When PII is present
<img width="1366" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/790af341-e106-4b11-aa66-c94ab6aa1770">

When PII is not present
<img width="1195" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/d1fe47bd-046d-4fde-8485-43ee448765c1">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1674](https://govukverify.atlassian.net/browse/KIWI-1674)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged


[KIWI-1674]: https://govukverify.atlassian.net/browse/KIWI-1674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ