### PR TITLE
KIWI-1308: Add CSLS subscription filter for Splunk onboarding

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -88,15 +88,15 @@ Mappings:
 
   PlatformConfiguration:
     dev:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     build:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     staging:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     integration:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     production:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
 
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
@@ -743,13 +743,13 @@ Resources:
           logretentionindays,
         ]
 
-  # SessionFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref SessionFunctionLogGroup
+  SessionFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref SessionFunctionLogGroup
 
   SessionFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -917,13 +917,13 @@ Resources:
           logretentionindays,
         ]
 
-  # AbortFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref AbortFunctionLogGroup
+  AbortFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref AbortFunctionLogGroup
 
   AbortFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1086,13 +1086,13 @@ Resources:
           logretentionindays,
         ]
 
-  # PersonInfoFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref PersonInfoFunctionLogGroup
+  PersonInfoFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref PersonInfoFunctionLogGroup
 
   PersonInfoFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1238,13 +1238,13 @@ Resources:
           logretentionindays,
         ]
 
-  # PersonInfoKeyFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref PersonInfoKeyFunctionLogGroup
+  PersonInfoKeyFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref PersonInfoKeyFunctionLogGroup
 
   PersonInfoKeyFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1421,13 +1421,13 @@ Resources:
           logretentionindays,
         ]
 
-  # UserInfoFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref UserInfoFunctionLogGroup
+  UserInfoFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref UserInfoFunctionLogGroup
 
   UserInfoFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1583,14 +1583,13 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/Access-Token-${AWS::StackName}"
       RetentionInDays: !FindInMap [ EnvironmentConfiguration, !Ref Environment, logretentionindays ]
 
-  # TokenFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #  # Condition: IsProdLikeEnvironment
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref TokenFunctionLogGroup
+  TokenFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref TokenFunctionLogGroup
 
   TokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1750,14 +1749,13 @@ Resources:
           logretentionindays,
         ]
 
-  # AuthorizationFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   # Condition: IsProdLikeEnvironment
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref AuthorizationFunctionLogGroup
+  AuthorizationFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref AuthorizationFunctionLogGroup
 
   AuthorizationFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1909,13 +1907,13 @@ Resources:
           logretentionindays,
         ]
 
-  # VerifyAccountFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref VerifyAccountFunctionLogGroup
+  VerifyAccountFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref VerifyAccountFunctionLogGroup
 
   VerifyAccountFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -2288,6 +2286,14 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/JsonWebKeys-${AWS::StackName}"
       RetentionInDays: !FindInMap [ EnvironmentConfiguration, !Ref Environment, logretentionindays ]
 
+  JsonWebKeysFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref JsonWebKeysLogGroup
+
   JsonWebKeysFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -2446,6 +2452,14 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/lambda/HmrcToken-${AWS::StackName}"
       RetentionInDays: !FindInMap [ EnvironmentConfiguration, !Ref Environment, logretentionindays ]
+
+  HmrcTokenFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+      FilterPattern: ""
+      LogGroupName: !Ref HmrcTokenLogGroup
 
   HmrcTokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -2613,13 +2627,13 @@ Resources:
           logretentionindays,
         ]
 
-  # PartialNameMatchFunctionLogsSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref PartialNameMatchFunctionLogGroup
+  PartialNameMatchFunctionLogsSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [ PlatformConfiguration, !Ref Environment, PartialNameMatchFunction ]
+      FilterPattern: ""
+      LogGroupName: !Ref PartialNameMatchFunctionLogGroup
 
   PartialNameMatchFunctionPermission:
     Type: AWS::Lambda::Permission

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -88,15 +88,15 @@ Mappings:
 
   PlatformConfiguration:
     dev:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     build:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     staging:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     integration:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     production:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
@@ -743,13 +743,13 @@ Resources:
           logretentionindays,
         ]
 
-  SessionFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-      FilterPattern: ""
-      LogGroupName: !Ref SessionFunctionLogGroup
+  # SessionFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref SessionFunctionLogGroup
 
   SessionFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -917,13 +917,13 @@ Resources:
           logretentionindays,
         ]
 
-  AbortFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-      FilterPattern: ""
-      LogGroupName: !Ref AbortFunctionLogGroup
+  # AbortFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref AbortFunctionLogGroup
 
   AbortFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1086,13 +1086,13 @@ Resources:
           logretentionindays,
         ]
 
-  PersonInfoFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-      FilterPattern: ""
-      LogGroupName: !Ref PersonInfoFunctionLogGroup
+  # PersonInfoFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref PersonInfoFunctionLogGroup
 
   PersonInfoFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1238,13 +1238,13 @@ Resources:
           logretentionindays,
         ]
 
-  PersonInfoKeyFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-      FilterPattern: ""
-      LogGroupName: !Ref PersonInfoKeyFunctionLogGroup
+  # PersonInfoKeyFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref PersonInfoKeyFunctionLogGroup
 
   PersonInfoKeyFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1421,13 +1421,13 @@ Resources:
           logretentionindays,
         ]
 
-  UserInfoFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-      FilterPattern: ""
-      LogGroupName: !Ref UserInfoFunctionLogGroup
+  # UserInfoFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref UserInfoFunctionLogGroup
 
   UserInfoFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1583,13 +1583,14 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/Access-Token-${AWS::StackName}"
       RetentionInDays: !FindInMap [ EnvironmentConfiguration, !Ref Environment, logretentionindays ]
 
-  TokenFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
-      FilterPattern: ""
-      LogGroupName: !Ref TokenFunctionLogGroup
+  # TokenFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #  # Condition: IsProdLikeEnvironment
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref TokenFunctionLogGroup
 
   TokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1749,13 +1750,14 @@ Resources:
           logretentionindays,
         ]
 
-  AuthorizationFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
-      FilterPattern: ""
-      LogGroupName: !Ref AuthorizationFunctionLogGroup
+  # AuthorizationFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   # Condition: IsProdLikeEnvironment
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref AuthorizationFunctionLogGroup
 
   AuthorizationFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -1907,13 +1909,13 @@ Resources:
           logretentionindays,
         ]
 
-  VerifyAccountFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-      FilterPattern: ""
-      LogGroupName: !Ref VerifyAccountFunctionLogGroup
+  # VerifyAccountFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref VerifyAccountFunctionLogGroup
 
   VerifyAccountFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -2286,14 +2288,6 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/JsonWebKeys-${AWS::StackName}"
       RetentionInDays: !FindInMap [ EnvironmentConfiguration, !Ref Environment, logretentionindays ]
 
-  JsonWebKeysFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-      FilterPattern: ""
-      LogGroupName: !Ref JsonWebKeysLogGroup
-
   JsonWebKeysFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -2452,14 +2446,6 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/lambda/HmrcToken-${AWS::StackName}"
       RetentionInDays: !FindInMap [ EnvironmentConfiguration, !Ref Environment, logretentionindays ]
-
-  HmrcTokenFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
-      FilterPattern: ""
-      LogGroupName: !Ref HmrcTokenLogGroup
 
   HmrcTokenFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -2627,13 +2613,13 @@ Resources:
           logretentionindays,
         ]
 
-  PartialNameMatchFunctionLogsSubscriptionFilterCSLS:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, PartialNameMatchFunction ]
-      FilterPattern: ""
-      LogGroupName: !Ref PartialNameMatchFunctionLogGroup
+  # PartialNameMatchFunctionLogsSubscriptionFilterCSLS:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Properties:
+  #     DestinationArn:
+  #       !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref PartialNameMatchFunctionLogGroup
 
   PartialNameMatchFunctionPermission:
     Type: AWS::Lambda::Permission

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2631,7 +2631,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn:
-        !FindInMap [ PlatformConfiguration, !Ref Environment, PartialNameMatchFunction ]
+        !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
       FilterPattern: ""
       LogGroupName: !Ref PartialNameMatchFunctionLogGroup
 

--- a/test-harness/template.yaml
+++ b/test-harness/template.yaml
@@ -35,12 +35,6 @@ Mappings:
       logretentionindays: 3
       apiTracingEnabled: true
 
-  PlatformConfiguration:
-    dev:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-    build:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
       TESTHARNESSURL: "testharness.review-bav.dev.account.gov.uk"


### PR DESCRIPTION
## Proposed changes
- Add CSLS subscription filter for the spunk onboarding. 
- Modified CSLS Egress stub 2

### What changed
- Enabled the CSLS filter subscription as splunk onboarding started
- BAV Accounts are added on the CSLS accounts which allows to push log groups
<!-- Describe the changes in detail - the "what"-->

### Why did it change
- For onboarding BAV CRI logs into splunk

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1308](https://govukverify.atlassian.net/browse/KIWI-1308)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1308]: https://govukverify.atlassian.net/browse/KIWI-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ