### PR TITLE
[KIWI-1590] - Add missing import to ApiTestSteps

### DIFF
--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -10,6 +10,7 @@ import { ISessionItem } from "../../models/ISessionItem";
 import { jwtUtils } from "../../utils/JwtUtils";
 import { BankDetailsPayload } from "../models/BankDetailsPayload";
 import NodeRSA = require("node-rsa");
+import crypto from "node:crypto";
 
 const API_INSTANCE = axios.create({ baseURL: constants.DEV_CRI_BAV_API_URL });
 const ajv = new Ajv({ strict: false });


### PR DESCRIPTION
### What changed

Fix for [KIWI-1590](https://govukverify.atlassian.net/browse/KIWI-1590)
Added new line to include missing import, this is causing api tests to fail in the pipeline

[KIWI-1590]: https://govukverify.atlassian.net/browse/KIWI-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ