### PR TITLE
Kiwi 1738 QA - Update JSON Schema for BAV TxMA Validation

### DIFF
--- a/src/tests/data/BAV_COP_REQUEST_SENT_SCHEMA.json
+++ b/src/tests/data/BAV_COP_REQUEST_SENT_SCHEMA.json
@@ -93,10 +93,22 @@
               ]
             }
           ]
+        },
+        "device_information": {
+          "type": "object",
+          "properties": {
+            "encoded": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "encoded"
+          ]
         }
       },
       "required": [
-        "CoP_request_details"
+        "CoP_request_details",
+        "device_information"
       ]
     }
   },

--- a/src/tests/data/BAV_COP_RESPONSE_RECEIVED_SCHEMA.json
+++ b/src/tests/data/BAV_COP_RESPONSE_RECEIVED_SCHEMA.json
@@ -62,6 +62,25 @@
       "required": [
         "evidence"
       ]
+    },
+    "restricted": {
+      "type": "object",
+      "properties": {
+        "device_information": {
+          "type": "object",
+          "properties": {
+            "encoded": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "encoded"
+          ]
+        }
+      },
+      "required": [
+        "device_information"
+      ]
     }
   },
   "required": [
@@ -71,7 +90,8 @@
     "timestamp",
     "event_timestamp_ms",
     "component_id",
-    "extensions"
+    "extensions",
+    "restricted"
   ],
   "additionalProperties": false
 }

--- a/src/tests/data/BAV_CRI_END_SCHEMA.json
+++ b/src/tests/data/BAV_CRI_END_SCHEMA.json
@@ -23,6 +23,7 @@
       "required": [
         "user_id",
         "session_id",
+        "govuk_signin_journey_id",
         "ip_address"
       ]
     },
@@ -37,6 +38,25 @@
     },
     "component_id": {
       "type": "string"
+    },
+    "restricted": {
+      "type": "object",
+      "properties": {
+        "device_information": {
+          "type": "object",
+          "properties": {
+            "encoded": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "encoded"
+          ]
+        }
+      },
+      "required": [
+        "device_information"
+      ]
     }
   },
   "required": [
@@ -45,7 +65,8 @@
     "client_id",
     "timestamp",
     "event_timestamp_ms",
-    "component_id"
+    "component_id",
+    "restricted"
   ],
   "additionalProperties": false
 }

--- a/src/tests/data/BAV_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/src/tests/data/BAV_CRI_SESSION_ABORTED_SCHEMA.json
@@ -23,6 +23,7 @@
       "required": [
         "user_id",
         "session_id",
+        "govuk_signin_journey_id",
         "ip_address"
       ]
     },
@@ -37,6 +38,25 @@
     },
     "component_id": {
       "type": "string"
+    },
+    "restricted": {
+      "type": "object",
+      "properties": {
+        "device_information": {
+          "type": "object",
+          "properties": {
+            "encoded": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "encoded"
+          ]
+        }
+      },
+      "required": [
+        "device_information"
+      ]
     }
   },
   "required": [
@@ -45,7 +65,8 @@
     "client_id",
     "timestamp",
     "event_timestamp_ms",
-    "component_id"
+    "component_id",
+    "restricted"
   ],
   "additionalProperties": false
 }

--- a/src/tests/data/BAV_CRI_START_SCHEMA.json
+++ b/src/tests/data/BAV_CRI_START_SCHEMA.json
@@ -38,6 +38,25 @@
     },
     "component_id": {
       "type": "string"
+    },
+    "restricted": {
+      "type": "object",
+      "properties": {
+        "device_information": {
+          "type": "object",
+          "properties": {
+            "encoded": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "encoded"
+          ]
+        }
+      },
+      "required": [
+        "device_information"
+      ]
     }
   },
   "required": [
@@ -46,7 +65,8 @@
     "client_id",
     "timestamp",
     "event_timestamp_ms",
-    "component_id"
+    "component_id",
+    "restricted"
   ],
   "additionalProperties": false
 }

--- a/src/tests/data/BAV_CRI_VC_ISSUED_SCHEMA.json
+++ b/src/tests/data/BAV_CRI_VC_ISSUED_SCHEMA.json
@@ -109,11 +109,23 @@
               ]
             }
           ]
+        },
+        "device_information": {
+          "type": "object",
+          "properties": {
+            "encoded": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "encoded"
+          ]
         }
       },
       "required": [
         "name",
-        "bankAccount"
+        "bankAccount",
+        "device_information"
       ]
     },
     "extensions": {
@@ -137,23 +149,12 @@
                 "attemptNum": {
                   "type": "integer"
                 },
-                "ci": {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
                 "ciReasons": {
                   "type": "array",
                   "items": [
                     {
                       "type": "object",
                       "properties": {
-                        "ci": {
-                          "type": "string"
-                        },
                         "reason": {
                           "type": "string"
                         }
@@ -169,7 +170,8 @@
                 "txn",
                 "strengthScore",
                 "validityScore",
-                "attemptNum"
+                "attemptNum",
+                "ciReasons"
               ]
             }
           ]


### PR DESCRIPTION
Test results: 
<img width="353" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/110032361/efbd3c2f-d7c7-45ee-b610-8fa18d3b2b7a">

BE Stack: bav-cri-api-1738

## Proposed changes

### What changed

Update JSON Schema for BAV TxMA Validation following the introduction of restricted.device_information.encoded field

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1738](https://govukverify.atlassian.net/browse/KIWI-1738)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1738]: https://govukverify.atlassian.net/browse/KIWI-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ