### PR TITLE
[KIWI-1692]Move govuk-signin-journey-id to Logger Context earlier

### DIFF
--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -118,6 +118,11 @@ export class SessionRequestProcessor {
   		return UnauthorizedResponse;
   	}
 
+  	const jwtPayload: JwtPayload = parsedJwt.payload;
+  	this.logger.appendKeys({
+  		govuk_signin_journey_id: jwtPayload.govuk_signin_journey_id as string,
+  	});
+
   	try {
   		if (configClient.jwksEndpoint) {
   			const payload = await this.kmsDecryptor.verifyWithJwks(urlEncodedJwt, configClient.jwksEndpoint);
@@ -141,19 +146,14 @@ export class SessionRequestProcessor {
   		});
   		return UnauthorizedResponse;
   	}
-
-  	const jwtPayload: JwtPayload = parsedJwt.payload;
+  	
   	const JwtErrors = isJwtValid(jwtPayload, requestBodyClientId, configClient.redirectUri);
   	if (JwtErrors.length > 0) {
   		this.logger.error(JwtErrors, {
   			messageCode: MessageCodes.FAILED_VALIDATING_JWT,
   		});
   		return UnauthorizedResponse;
-  	}
-
-  	this.logger.appendKeys({
-  		govuk_signin_journey_id: jwtPayload.govuk_signin_journey_id as string,
-  	});
+  	}  	
 
   	const personDetailsError = isPersonNameValid(jwtPayload.shared_claims.name);
   	if (!personDetailsError) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Move govuk-signin-journey-id to Logger Context earlier as soon the jwt is decoded.

### Why did it change

prod errors not capturing the journey-id earlier hence issues with missing info in shared_claims are being missed

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1692](https://govukverify.atlassian.net/browse/KIWI-1692)



[KIWI-1692]: https://govukverify.atlassian.net/browse/KIWI-1692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ