### PR TITLE
KIWI-1771: Update tests to include txma-audit-encoded header

### DIFF
--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -69,7 +69,7 @@ export async function stubStartPost(bavStubPayload?: StubStartRequest): Promise<
 export async function sessionPost(clientId: string, request: string): Promise<AxiosResponse<SessionResponse>> {
 	const path = "/session";
 	try {
-		const postRequest = await API_INSTANCE.post(path, { client_id: clientId, request });
+		const postRequest = await API_INSTANCE.post(path, { client_id: clientId, request }, { headers: { "txma-audit-encoded": "encoded-header" } });
 		expect(postRequest.status).toBe(200);
 		return postRequest;
 	} catch (error: any) {
@@ -105,7 +105,7 @@ export async function personInfoKeyGet(): Promise<AxiosResponse<{ key: string }>
 export async function verifyAccountPost(bankDetails: BankDetailsPayload, sessionId: string): Promise<AxiosResponse<VerifyAccountResponse>> {
 	const path = "/verify-account";
 	try {
-		const postRequest = await API_INSTANCE.post(path, JSON.stringify(bankDetails), { headers: { "x-govuk-signin-session-id": sessionId } });
+		const postRequest = await API_INSTANCE.post(path, JSON.stringify(bankDetails), { headers: { "x-govuk-signin-session-id": sessionId, "txma-audit-encoded": "encoded-header" } });
 		return postRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
@@ -252,7 +252,7 @@ export function decodeRawBody(rawBody: any): any {
 export async function abortPost(sessionId: string): Promise<AxiosResponse<string>> {
 	const path = "/abort";
 	try {
-		const postRequest = await API_INSTANCE.post(path, null, { headers: { "x-govuk-signin-session-id": sessionId } });
+		const postRequest = await API_INSTANCE.post(path, null, { headers: { "x-govuk-signin-session-id": sessionId, "txma-audit-encoded": "encoded-header" } });
 		return postRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);

--- a/src/tests/api/ApiUtils.ts
+++ b/src/tests/api/ApiUtils.ts
@@ -99,7 +99,7 @@ export function validateTxMAEventData(
 				throw new Error(`Could not find schema ${schemaName}`);
 			}
 		} catch (error) {
-			console.error("Error validating event", error);
+			console.error(`Error validating event ${eventName}`, error);
 			throw error;
 		}
 	} else {

--- a/src/tests/data/BAV_CRI_END_SCHEMA.json
+++ b/src/tests/data/BAV_CRI_END_SCHEMA.json
@@ -35,25 +35,6 @@
     },
     "component_id": {
       "type": "string"
-    },
-    "restricted": {
-      "type": "object",
-      "properties": {
-        "device_information": {
-          "type": "object",
-          "properties": {
-            "encoded": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "encoded"
-          ]
-        }
-      },
-      "required": [
-        "device_information"
-      ]
     }
   },
   "required": [
@@ -61,8 +42,7 @@
     "user",
     "timestamp",
     "event_timestamp_ms",
-    "component_id",
-    "restricted"
+    "component_id"
   ],
   "additionalProperties": false
 }

--- a/src/tests/data/BAV_CRI_VC_ISSUED_SCHEMA.json
+++ b/src/tests/data/BAV_CRI_VC_ISSUED_SCHEMA.json
@@ -106,23 +106,11 @@
               ]
             }
           ]
-        },
-        "device_information": {
-          "type": "object",
-          "properties": {
-            "encoded": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "encoded"
-          ]
         }
       },
       "required": [
         "name",
-        "bankAccount",
-        "device_information"
+        "bankAccount"
       ]
     },
     "extensions": {


### PR DESCRIPTION
## Proposed changes

### What changed

- Included the TxMA header in API test calls where it should exist (user - machine)
- Updated Schemas for events where the header is not going to be present (machine - machine)

### Screenshots

<img width="319" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-api/assets/40401118/6148db54-2c9c-40de-8a74-ee2ce2818b21">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1771](https://govukverify.atlassian.net/browse/KIWI-1771)

