### PR TITLE
[KIWI-1841] Add Athena queries to the Cloudformation template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3988,6 +3988,15 @@ Resources:
             KmsKey: !Ref PartialNameMatchBucketKeyAlias
           ExpectedBucketOwner: !Ref AWS::AccountId
           OutputLocation: !Sub "s3://${PartialNameMatchAthenaResultsBucket}/"
+  
+  PartialNameMatchAthenaNamedQuery:
+    Type: AWS::Athena::NamedQuery
+    Properties:
+      Database: !Ref PartialNameMatchGlueDatabase
+      Description: "A query to return all the partial name records in the last 7 days."
+      Name: "PartialNameRecordsInLast7Days"
+      WorkGroup: !Ref PartialNameMatchAthenaWorkgroup
+      QueryString: !Sub SELECT *,from_unixtime(timestamp) AS human_readable_timestamp FROM "partialnamematch-${AWS::StackName}" WHERE timestamp >= to_unixtime(current_date - interval '7' day) order by human_readable_timestamp asc;
 
   JsonWebKeysFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Adding Athena query to the Cloudformation template which can be viewed as Saved queries for our Workspace and one can simply run the query to view the result.
Confluence [page](https://govukverify.atlassian.net/wiki/spaces/BAC/pages/4169924716/How+to+list+Partial+Names+in+Athena) has been updated with the steps to view the Saved queries and run it to view the results.

### Why did it change

Enhancement requirement

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1841](https://govukverify.atlassian.net/browse/KIWI-1841)

Evidence of the same attached for ref;

https://github.com/govuk-one-login/ipv-cri-bav-api/assets/115095929/46d6eada-b353-4b81-b6f2-09681984cc97



[KIWI-1841]: https://govukverify.atlassian.net/browse/KIWI-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ