### PR TITLE
Add env param for BAV

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -97,6 +97,14 @@ Mappings:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     production:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+  
+  BAVServiceProviderMapping:
+    Environment:
+      dev: "EXPERIAN"
+      build: "EXPERIAN"
+      staging: "EXPERIAN"
+      integration: "EXPERIAN"
+      production: "EXPERIAN"
 
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
@@ -577,6 +585,13 @@ Resources:
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
 
+  BAVServiceProviderParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${Environment}/BAVServiceProvider"
+      Type: String
+      Value: !FindInMap [BAVServiceProviderMapping, Environment, !Ref Environment]
+      Description: Feature flag to set which service is used to verify bank accounts
 
   ### Start of API Gateway definition.
 


### PR DESCRIPTION
### What changed

Added SSM parameter to specify which service BAV should be pointing to (HMRC or Experian)

### Issue tracking

- [KIWI-1926](https://govukverify.atlassian.net/browse/KIWI-1926)

### Evidence
![image](https://github.com/user-attachments/assets/4b187dad-7978-436e-b75d-b4f230122148)
![image](https://github.com/user-attachments/assets/bd1e1188-0874-4cfc-afca-42e1ab421550)
![image](https://github.com/user-attachments/assets/943bf96c-cd84-468c-ae16-7a645883dac5)


[KIWI-1926]: https://govukverify.atlassian.net/browse/KIWI-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ