### PR TITLE
IPS-1098: Implement Lambda canary deployment for BAV CRI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ Checkov..............................................(no files to check)Skipped
 - hook id: checkov
 ```
 
+## Canaries
+When deploying using sam deploy, canary deployment strategy will be used which is set in LambdaDeploymentPreference in template.yaml file.
+
+When deploying using the pipeline, canary deployment strategy set in the pipeline will be used and override the default set in template.yaml.
+
+Canary deployments will cause a rollback if any canary alarms associated with a lambda are triggered.
+
+To skip canaries such as when releasing urgent changes to production, set the last commit message to contain either of these phrases: [skip canary], [canary skip], or [no canary] as specified in the [Canary Escape Hatch guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3836051600/Rollback+Recovery+Guidance#Escape-Hatch%3A-how-to-skip-canary-deployments-when-needed).codde 
+`git commit -m "some message [skip canary]"`
+
+Note: To update LambdaDeploymentPreference, update the LambdaCanaryDeployment pipeline parameter in the [identity-common-infra repository](https://github.com/govuk-one-login/identity-common-infra/tree/main/terraform/kiwi/bav).

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -905,10 +905,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-SessionFunction:live"
-        - Name: FunctionName
-          Value: !Ref SessionFunction
         - Name: ExecutedVersion
-          Value: !GetAtt SessionFunction.Version.Version
+          Value: !Sub SessionFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -1408,10 +1406,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-AbortFunction:live"
-        - Name: FunctionName
-          Value: !Ref AbortFunction
         - Name: ExecutedVersion
-          Value: !GetAtt AbortFunction.Version.Version
+          Value: !Sub AbortFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -1825,10 +1821,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-PersonInfoFunction:live"
-        - Name: FunctionName
-          Value: !Ref PersonInfoFunction
         - Name: ExecutedVersion
-          Value: !GetAtt PersonInfoFunction.Version.Version
+          Value: !Sub PersonInfoFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -2225,10 +2219,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-PersonInfoKeyFunction:live"
-        - Name: FunctionName
-          Value: !Ref PersonInfoKeyFunction
         - Name: ExecutedVersion
-          Value: !GetAtt PersonInfoKeyFunction.Version.Version
+          Value: !Sub PersonInfoKeyFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -2660,10 +2652,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-UserInfoFunction:live"
-        - Name: FunctionName
-          Value: !Ref UserInfoFunction
         - Name: ExecutedVersion
-          Value: !GetAtt UserInfoFunction.Version.Version
+          Value: !Sub UserInfoFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -3073,10 +3063,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-TokenFunction:live"
-        - Name: FunctionName
-          Value: !Ref TokenFunction
         - Name: ExecutedVersion
-          Value: !GetAtt TokenFunction.Version.Version
+          Value: !Sub TokenFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -3489,10 +3477,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-AuthorizationFunction:live"
-        - Name: FunctionName
-          Value: !Ref AuthorizationFunction
         - Name: ExecutedVersion
-          Value: !GetAtt AuthorizationFunction.Version.Version
+          Value: !Sub AuthorizationFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -3933,10 +3919,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-VerifyAccountFunction:live"
-        - Name: FunctionName
-          Value: !Ref VerifyAccountFunction
         - Name: ExecutedVersion
-          Value: !GetAtt VerifyAccountFunction.Version.Version
+          Value: !Sub VerifyAccountFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -5025,10 +5009,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-HmrcTokenFunction:live"
-        - Name: FunctionName
-          Value: !Ref HmrcTokenFunction
         - Name: ExecutedVersion
-          Value: !GetAtt HmrcTokenFunction.Version.Version
+          Value: !Sub HmrcTokenFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
@@ -5231,10 +5213,8 @@ Resources:
       Dimensions:
         - Name: Resource
           Value: !Sub "${AWS::StackName}-PartialNameMatchFunction:live"
-        - Name: FunctionName
-          Value: !Ref PartialNameMatchFunction
         - Name: ExecutedVersion
-          Value: !GetAtt PartialNameMatchFunction.Version.Version
+          Value: !Sub PartialNameMatchFunction.Version.Version
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -891,7 +891,7 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-SessionFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs. ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -1395,7 +1395,7 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AbortFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs. ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -1813,7 +1813,7 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PersonInfoFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs. ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -2214,7 +2214,7 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PersonInfoKeyFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs. ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -2650,7 +2650,7 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-UserInfoFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs. ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -3064,7 +3064,7 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-TokenFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs. ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -3481,7 +3481,7 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AuthorizationFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs. ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -3926,7 +3926,7 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-VerifyAccountFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs. ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
@@ -4904,13 +4904,6 @@ Resources:
         - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
-      # DeploymentPreference:
-      #   Type: !Ref LambdaDeploymentPreference
-      #   Role: !GetAtt CodeDeployServiceRole.Arn
-      #   Alarms: !If
-      #     - UseCanaryDeploymentAlarms
-      #     - [!Ref HmrcTokenFunctionFatalErrorAlarm, !Ref HmrcTokenFunctionLambdaErrors]
-      #     - [!Ref AWS::NoValue]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: HmrcTokenHandler
@@ -5014,32 +5007,6 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  # HmrcTokenFunctionLambdaErrors:
-  #   Type: AWS::CloudWatch::Alarm
-  #   Condition: UseCanaryDeploymentAlarms
-  #   Properties:
-  #     AlarmName: !Sub "${AWS::StackName}-HmrcTokenFunctionLambdaErrors"
-  #     AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
-  #     ActionsEnabled: true
-  #     AlarmActions:
-  #       - !ImportValue platform-alarm-topic-slack-warning-alert
-  #     OKActions:
-  #       - !ImportValue platform-alarm-topic-slack-warning-alert
-  #     InsufficientDataActions: []
-  #     MetricName: Errors
-  #     Namespace: AWS/Lambda
-  #     Statistic: Sum
-  #     Dimensions:
-  #       - Name: Resource
-  #         Value: !Sub "${AWS::StackName}-HmrcTokenFunction:live"
-  #       - Name: ExecutedVersion
-  #         Value: !Sub HmrcTokenFunction.Version.Version
-  #     Period: 60
-  #     EvaluationPeriods: 1
-  #     Threshold: 1
-  #     ComparisonOperator: GreaterThanThreshold
-  #     TreatMissingData: notBreaching
-
   HmrcTokenConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
     Condition: "ApplyReservedConcurrency"
@@ -5096,13 +5063,13 @@ Resources:
     DependsOn: PartialNameMatchFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-PartialNameMatch-${AWS::StackName}"
-      # DeploymentPreference:
-      #   Type: !Ref LambdaDeploymentPreference
-      #   Role: !GetAtt CodeDeployServiceRole.Arn
-      #   Alarms: !If
-      #     - UseCanaryDeploymentAlarms
-      #     - [!Ref PartialNameMatchFunctionFatalErrorAlarm, !Ref PartialNameMatchFunctionLambdaErrors]
-      #     - [!Ref AWS::NoValue]
+      DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref PartialNameMatchFunctionFatalErrorAlarm, !Ref PartialNameMatchFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: PartialNameMatchHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -5185,6 +5152,13 @@ Resources:
       FunctionName: !Ref PartialNameMatchFunction
       Principal: apigateway.amazonaws.com
 
+  PartialNameMatchFunctionPermissionAlias:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref PartialNameMatchFunction.Alias
+      Principal: apigateway.amazonaws.com
+
   PartialNameMatchFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -5220,31 +5194,31 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  # PartialNameMatchFunctionLambdaErrors:
-  #   Type: AWS::CloudWatch::Alarm
-  #   Condition: UseCanaryDeploymentAlarms
-  #   Properties:
-  #     AlarmName: !Sub "${AWS::StackName}-PartialNameMatchFunctionLambdaErrors"
-  #     AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
-  #     ActionsEnabled: true
-  #     AlarmActions:
-  #       - !ImportValue platform-alarm-topic-slack-warning-alert
-  #     OKActions:
-  #       - !ImportValue platform-alarm-topic-slack-warning-alert
-  #     InsufficientDataActions: []
-  #     MetricName: Errors
-  #     Namespace: AWS/Lambda
-  #     Statistic: Sum
-  #     Dimensions:
-  #       - Name: Resource
-  #         Value: !Sub "${AWS::StackName}-PartialNameMatchFunction:live"
-  #       - Name: ExecutedVersion
-  #         Value: !Sub PartialNameMatchFunction.Version.Version
-  #     Period: 60
-  #     EvaluationPeriods: 1
-  #     Threshold: 1
-  #     ComparisonOperator: GreaterThanThreshold
-  #     TreatMissingData: notBreaching
+  PartialNameMatchFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-PartialNameMatchFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-PartialNameMatchFunction:live"
+        - Name: ExecutedVersion
+          Value: !Sub PartialNameMatchFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
 
   PartialNameMatchConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -62,6 +62,10 @@ Parameters:
     Description: "Set to true to apply reserved concurrency when deploying in DEV environments"
     Type: String
     Default: "false"
+  LambdaDeploymentPreference:
+    Description: "Specifies the configuration to enable gradual Lambda deployments. This value is picked up from the LambdaCanaryDeployment on the pipeline "
+    Type: String
+    Default: AllAtOnce
 
 Mappings:
   EnvironmentConfiguration: # This is where you store per-environment settings.
@@ -211,6 +215,7 @@ Conditions:
       - Fn::Equals:
           - !Ref SecretPrefix
           - "none"
+  UseCanaryDeploymentAlarms: !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
   DeployAlarms: !Or
     - Condition: IsNotDevelopment
     - !Equals [!Ref DeployAlarmsInDev, true]
@@ -292,6 +297,9 @@ Globals:
           !Ref AWS::StackName,
         ]
     AutoPublishAlias: live
+    DeploymentPreference:
+      Type: !Ref LambdaDeploymentPreference
+      Role: !GetAtt CodeDeployServiceRole.Arn
 
 Resources:
   LambdaEgressSecurityGroup:
@@ -746,6 +754,11 @@ Resources:
     DependsOn: SessionFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-Session-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref SessionFunctionFatalErrorAlarm, !Ref SessionFunctionCanary5xxErrors, !Ref SessionFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: SessionHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -841,7 +854,6 @@ Resources:
 
   SessionFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref SessionFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -855,7 +867,6 @@ Resources:
     DependsOn:
       - "SessionFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-SessionFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -872,6 +883,64 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  SessionFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-SessionFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-SessionFunction:live"
+        - Name: FunctionName
+          Value: !Ref SessionFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt SessionFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  SessionFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmName: !Sub "${AWS::StackName}-SessionFunctionCanary5xxErrors"
+      AlarmDescription: !Sub "SessionFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: Method
+          Value: POST
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} - BAV Credential Issuer Private API"
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /session
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -1199,6 +1268,11 @@ Resources:
     DependsOn: AbortFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-Abort-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref AbortFunctionFatalErrorAlarm, !Ref AbortFunctionLambdaErrors, !Ref AbortFunctionCanary5xxErrors]
+          - [!Ref AWS::NoValue]
       Handler: AbortHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -1283,7 +1357,6 @@ Resources:
 
   AbortFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref AbortFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -1297,7 +1370,6 @@ Resources:
     DependsOn:
       - "AbortFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AbortFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -1314,6 +1386,64 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  AbortFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-AbortFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-AbortFunction:live"
+        - Name: FunctionName
+          Value: !Ref AbortFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt AbortFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  AbortFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmName: !Sub "${AWS::StackName}-AbortFunctionCanary5xxErrors"
+      AlarmDescription: !Sub "AbortFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: Method
+          Value: POST
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} - BAV Credential Issuer Private API"
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /abort
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -1560,6 +1690,11 @@ Resources:
     DependsOn: PersonInfoFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-person-info-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref PersonInfoFunctionFatalErrorAlarm, !Ref PersonInfoFunctionCanary5xxErrors, !Ref PersonInfoFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: PersonInfoHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -1639,7 +1774,6 @@ Resources:
 
   PersonInfoFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref PersonInfoFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -1653,7 +1787,6 @@ Resources:
     DependsOn:
       - "PersonInfoFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PersonInfoFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -1672,6 +1805,34 @@ Resources:
       DatapointsToAlarm: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  PersonInfoFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-PersonInfoFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-PersonInfoFunction:live"
+        - Name: FunctionName
+          Value: !Ref PersonInfoFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt PersonInfoFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
   PersonInfoConcurrency80Alarm:
@@ -1697,6 +1858,36 @@ Resources:
       DatapointsToAlarm: 1
       Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  PersonInfoFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmName: !Sub "${AWS::StackName}-PersonInfoFunctionCanary5xxErrors"
+      AlarmDescription: !Sub "PersonInfoFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: Method
+          Value: GET
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} - BAV Credential Issuer Private API"
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /person-info
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
   PersonInfoThrottleAlarm:
@@ -1916,6 +2107,11 @@ Resources:
     DependsOn: PersonInfoKeyFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-Person-Info-Key-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref PersonInfoKeyFunctionFatalErrorAlarm, !Ref PersonInfoKeyFunctionCanary5xxErrors, !Ref PersonInfoKeyFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: PersonInfoKeyHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -1978,7 +2174,6 @@ Resources:
 
   PersonInfoKeyFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref PersonInfoKeyFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -1992,7 +2187,6 @@ Resources:
     DependsOn:
       - "PersonInfoKeyFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PersonInfoKeyFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -2009,6 +2203,64 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  PersonInfoKeyFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-PersonInfoKeyFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-PersonInfoKeyFunction:live"
+        - Name: FunctionName
+          Value: !Ref PersonInfoKeyFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt PersonInfoKeyFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  PersonInfoKeyFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmName: !Sub "${AWS::StackName}-PersonInfoKeyFunctionCanary5xxErrors"
+      AlarmDescription: !Sub "PersonInfoKeyFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: Method
+          Value: GET
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} - BAV Credential Issuer Private API"
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /person-info
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -2255,6 +2507,11 @@ Resources:
     DependsOn: UserInfoFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-UserInfo-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref UserInfoFunctionFatalErrorAlarm, !Ref UserInfoFunctionCanary5xxErrors, !Ref UserInfoFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: UserInfoHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -2352,7 +2609,6 @@ Resources:
 
   UserInfoFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref UserInfoFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -2366,7 +2622,6 @@ Resources:
     DependsOn:
       - "UserInfoFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-UserInfoFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -2383,6 +2638,64 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  UserInfoFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-UserInfoFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-UserInfoFunction:live"
+        - Name: FunctionName
+          Value: !Ref UserInfoFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt UserInfoFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  UserInfoFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmName: !Sub "${AWS::StackName}-UserInfoFunctionCanary5xxErrors"
+      AlarmDescription: !Sub "UserInfoFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: Method
+          Value: POST
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} - BAV Credential Issuer Private API"
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /userinfo
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -2631,6 +2944,11 @@ Resources:
     DependsOn: TokenFunctionLogGroup
     Properties:
       FunctionName: !Sub "Access-Token-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref TokenFunctionFatalErrorAlarm, !Ref TokenFunctionCanary5xxErrors, !Ref TokenFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: AccessTokenHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -2704,7 +3022,6 @@ Resources:
 
   TokenFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref TokenFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -2718,7 +3035,6 @@ Resources:
     DependsOn:
       - "TokenFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-TokenFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -2735,6 +3051,64 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  TokenFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-TokenFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-TokenFunction:live"
+        - Name: FunctionName
+          Value: !Ref TokenFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt TokenFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  TokenFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmName: !Sub "${AWS::StackName}-TokenFunctionCanary5xxErrors"
+      AlarmDescription: !Sub "TokenFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: Method
+          Value: POST
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} - BAV Credential Issuer Private API"
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /token
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -2982,6 +3356,11 @@ Resources:
     DependsOn: AuthorizationFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-Authorization-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref AuthorizationFunctionFatalErrorAlarm, !Ref AuthorizationFunctionCanary5xxErrors, !Ref AuthorizationFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: AuthorizationHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -3059,7 +3438,6 @@ Resources:
 
   AuthorizationFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref AuthorizationFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -3073,7 +3451,6 @@ Resources:
     DependsOn:
       - "AuthorizationFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AuthorizationFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -3090,6 +3467,64 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  AuthorizationFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-AuthorizationFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-AuthorizationFunction:live"
+        - Name: FunctionName
+          Value: !Ref AuthorizationFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt AuthorizationFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  AuthorizationFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmName: !Sub "${AWS::StackName}-AuthorizationFunctionCanary5xxErrors"
+      AlarmDescription: !Sub "AuthorizationFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: Method
+          Value: GET
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} - BAV Credential Issuer Private API"
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /authorization
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -3288,6 +3723,11 @@ Resources:
     DependsOn: VerifyAccountFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-verify-account-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref VerifyAccountFunctionFatalErrorAlarm, !Ref VerifyAccountFunctionCanary5xxErrors, !Ref VerifyAccountFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: VerifyAccountHandler.lambdaHandler
       Timeout: 75
       CodeUri: ../src/
@@ -3442,7 +3882,6 @@ Resources:
 
   VerifyAccountFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref VerifyAccountFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -3456,7 +3895,6 @@ Resources:
     DependsOn:
       - "VerifyAccountFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-VerifyAccountFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -3473,6 +3911,64 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  VerifyAccountFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-VerifyAccountFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-VerifyAccountFunction:live"
+        - Name: FunctionName
+          Value: !Ref VerifyAccountFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt VerifyAccountFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  VerifyAccountFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmName: !Sub "${AWS::StackName}-VerifyAccountFunctionCanary5xxErrors"
+      AlarmDescription: !Sub "VerifyAccountFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: Method
+          Value: POST
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName} - BAV Credential Issuer Private API"
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /verify-account
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -4119,7 +4615,6 @@ Resources:
 
   JsonWebKeysFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref JsonWebKeysLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -4133,7 +4628,6 @@ Resources:
     DependsOn:
       - "JsonWebKeysFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-JsonWebKeysFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -4405,6 +4899,11 @@ Resources:
         - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref HmrcTokenFunctionFatalErrorAlarm, !Ref HmrcTokenFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: HmrcTokenHandler
@@ -4475,7 +4974,6 @@ Resources:
 
   HmrcTokenFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref HmrcTokenLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -4489,7 +4987,6 @@ Resources:
     DependsOn:
       - "HmrcTokenFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-HmrcTokenFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -4508,6 +5005,34 @@ Resources:
       DatapointsToAlarm: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  HmrcTokenFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-HmrcTokenFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-HmrcTokenFunction:live"
+        - Name: FunctionName
+          Value: !Ref HmrcTokenFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt HmrcTokenFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
   HmrcTokenConcurrency80Alarm:
@@ -4566,6 +5091,11 @@ Resources:
     DependsOn: PartialNameMatchFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-PartialNameMatch-${AWS::StackName}"
+      DeploymentPreference:
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref PartialNameMatchFunctionFatalErrorAlarm, !Ref PartialNameMatchFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
       Handler: PartialNameMatchHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -4650,7 +5180,6 @@ Resources:
 
   PartialNameMatchFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: DeployAlarms
     Properties:
       LogGroupName: !Ref PartialNameMatchFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -4664,7 +5193,6 @@ Resources:
     DependsOn:
       - "PartialNameMatchFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PartialNameMatchFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -4683,6 +5211,34 @@ Resources:
       DatapointsToAlarm: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  PartialNameMatchFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-PartialNameMatchFunctionLambdaErrors"
+      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-PartialNameMatchFunction:live"
+        - Name: FunctionName
+          Value: !Ref PartialNameMatchFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt PartialNameMatchFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
   PartialNameMatchConcurrency80Alarm:
@@ -4734,6 +5290,22 @@ Resources:
       DatapointsToAlarm: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
+
+  CodeDeployServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - codedeploy.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
 
 Outputs:
   BAVApiGatewayId:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -297,9 +297,6 @@ Globals:
           !Ref AWS::StackName,
         ]
     AutoPublishAlias: live
-    DeploymentPreference:
-      Type: !Ref LambdaDeploymentPreference
-      Role: !GetAtt CodeDeployServiceRole.Arn
 
 Resources:
   LambdaEgressSecurityGroup:
@@ -755,6 +752,8 @@ Resources:
     Properties:
       FunctionName: !Sub "BAV-Session-${AWS::StackName}"
       DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - [!Ref SessionFunctionFatalErrorAlarm, !Ref SessionFunctionCanary5xxErrors, !Ref SessionFunctionLambdaErrors]
@@ -938,7 +937,8 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -1267,6 +1267,8 @@ Resources:
     Properties:
       FunctionName: !Sub "BAV-Abort-${AWS::StackName}"
       DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - [!Ref AbortFunctionFatalErrorAlarm, !Ref AbortFunctionLambdaErrors, !Ref AbortFunctionCanary5xxErrors]
@@ -1439,7 +1441,8 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -1687,6 +1690,8 @@ Resources:
     Properties:
       FunctionName: !Sub "BAV-person-info-${AWS::StackName}"
       DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - [!Ref PersonInfoFunctionFatalErrorAlarm, !Ref PersonInfoFunctionCanary5xxErrors, !Ref PersonInfoFunctionLambdaErrors]
@@ -1879,7 +1884,8 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -2102,6 +2108,8 @@ Resources:
     Properties:
       FunctionName: !Sub "BAV-Person-Info-Key-${AWS::StackName}"
       DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - [!Ref PersonInfoKeyFunctionFatalErrorAlarm, !Ref PersonInfoKeyFunctionCanary5xxErrors, !Ref PersonInfoKeyFunctionLambdaErrors]
@@ -2252,7 +2260,8 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -2500,6 +2509,8 @@ Resources:
     Properties:
       FunctionName: !Sub "BAV-UserInfo-${AWS::StackName}"
       DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - [!Ref UserInfoFunctionFatalErrorAlarm, !Ref UserInfoFunctionCanary5xxErrors, !Ref UserInfoFunctionLambdaErrors]
@@ -2685,7 +2696,8 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -2935,6 +2947,8 @@ Resources:
     Properties:
       FunctionName: !Sub "Access-Token-${AWS::StackName}"
       DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - [!Ref TokenFunctionFatalErrorAlarm, !Ref TokenFunctionCanary5xxErrors, !Ref TokenFunctionLambdaErrors]
@@ -3096,7 +3110,8 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -3345,6 +3360,8 @@ Resources:
     Properties:
       FunctionName: !Sub "BAV-Authorization-${AWS::StackName}"
       DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - [!Ref AuthorizationFunctionFatalErrorAlarm, !Ref AuthorizationFunctionCanary5xxErrors, !Ref AuthorizationFunctionLambdaErrors]
@@ -3510,7 +3527,8 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -3710,6 +3728,8 @@ Resources:
     Properties:
       FunctionName: !Sub "BAV-verify-account-${AWS::StackName}"
       DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - [!Ref VerifyAccountFunctionFatalErrorAlarm, !Ref VerifyAccountFunctionCanary5xxErrors, !Ref VerifyAccountFunctionLambdaErrors]
@@ -3952,7 +3972,8 @@ Resources:
       Statistic: Sum
       Unit: Count
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -4883,11 +4904,13 @@ Resources:
         - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
-      DeploymentPreference:
-        Alarms: !If
-          - UseCanaryDeploymentAlarms
-          - [!Ref HmrcTokenFunctionFatalErrorAlarm, !Ref HmrcTokenFunctionLambdaErrors]
-          - [!Ref AWS::NoValue]
+      # DeploymentPreference:
+      #   Type: !Ref LambdaDeploymentPreference
+      #   Role: !GetAtt CodeDeployServiceRole.Arn
+      #   Alarms: !If
+      #     - UseCanaryDeploymentAlarms
+      #     - [!Ref HmrcTokenFunctionFatalErrorAlarm, !Ref HmrcTokenFunctionLambdaErrors]
+      #     - [!Ref AWS::NoValue]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: HmrcTokenHandler
@@ -4991,31 +5014,31 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  HmrcTokenFunctionLambdaErrors:
-    Type: AWS::CloudWatch::Alarm
-    Condition: UseCanaryDeploymentAlarms
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-HmrcTokenFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
-      ActionsEnabled: true
-      AlarmActions:
-        - !ImportValue platform-alarm-topic-slack-warning-alert
-      OKActions:
-        - !ImportValue platform-alarm-topic-slack-warning-alert
-      InsufficientDataActions: []
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Statistic: Sum
-      Dimensions:
-        - Name: Resource
-          Value: !Sub "${AWS::StackName}-HmrcTokenFunction:live"
-        - Name: ExecutedVersion
-          Value: !Sub HmrcTokenFunction.Version.Version
-      Period: 60
-      EvaluationPeriods: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
+  # HmrcTokenFunctionLambdaErrors:
+  #   Type: AWS::CloudWatch::Alarm
+  #   Condition: UseCanaryDeploymentAlarms
+  #   Properties:
+  #     AlarmName: !Sub "${AWS::StackName}-HmrcTokenFunctionLambdaErrors"
+  #     AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+  #     ActionsEnabled: true
+  #     AlarmActions:
+  #       - !ImportValue platform-alarm-topic-slack-warning-alert
+  #     OKActions:
+  #       - !ImportValue platform-alarm-topic-slack-warning-alert
+  #     InsufficientDataActions: []
+  #     MetricName: Errors
+  #     Namespace: AWS/Lambda
+  #     Statistic: Sum
+  #     Dimensions:
+  #       - Name: Resource
+  #         Value: !Sub "${AWS::StackName}-HmrcTokenFunction:live"
+  #       - Name: ExecutedVersion
+  #         Value: !Sub HmrcTokenFunction.Version.Version
+  #     Period: 60
+  #     EvaluationPeriods: 1
+  #     Threshold: 1
+  #     ComparisonOperator: GreaterThanThreshold
+  #     TreatMissingData: notBreaching
 
   HmrcTokenConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
@@ -5073,11 +5096,13 @@ Resources:
     DependsOn: PartialNameMatchFunctionLogGroup
     Properties:
       FunctionName: !Sub "BAV-PartialNameMatch-${AWS::StackName}"
-      DeploymentPreference:
-        Alarms: !If
-          - UseCanaryDeploymentAlarms
-          - [!Ref PartialNameMatchFunctionFatalErrorAlarm, !Ref PartialNameMatchFunctionLambdaErrors]
-          - [!Ref AWS::NoValue]
+      # DeploymentPreference:
+      #   Type: !Ref LambdaDeploymentPreference
+      #   Role: !GetAtt CodeDeployServiceRole.Arn
+      #   Alarms: !If
+      #     - UseCanaryDeploymentAlarms
+      #     - [!Ref PartialNameMatchFunctionFatalErrorAlarm, !Ref PartialNameMatchFunctionLambdaErrors]
+      #     - [!Ref AWS::NoValue]
       Handler: PartialNameMatchHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
@@ -5195,31 +5220,31 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  PartialNameMatchFunctionLambdaErrors:
-    Type: AWS::CloudWatch::Alarm
-    Condition: UseCanaryDeploymentAlarms
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-PartialNameMatchFunctionLambdaErrors"
-      AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
-      ActionsEnabled: true
-      AlarmActions:
-        - !ImportValue platform-alarm-topic-slack-warning-alert
-      OKActions:
-        - !ImportValue platform-alarm-topic-slack-warning-alert
-      InsufficientDataActions: []
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Statistic: Sum
-      Dimensions:
-        - Name: Resource
-          Value: !Sub "${AWS::StackName}-PartialNameMatchFunction:live"
-        - Name: ExecutedVersion
-          Value: !Sub PartialNameMatchFunction.Version.Version
-      Period: 60
-      EvaluationPeriods: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
+  # PartialNameMatchFunctionLambdaErrors:
+  #   Type: AWS::CloudWatch::Alarm
+  #   Condition: UseCanaryDeploymentAlarms
+  #   Properties:
+  #     AlarmName: !Sub "${AWS::StackName}-PartialNameMatchFunctionLambdaErrors"
+  #     AlarmDescription: !Sub Trigger an alarm when lambda errors occurs. ${SupportManualURL}
+  #     ActionsEnabled: true
+  #     AlarmActions:
+  #       - !ImportValue platform-alarm-topic-slack-warning-alert
+  #     OKActions:
+  #       - !ImportValue platform-alarm-topic-slack-warning-alert
+  #     InsufficientDataActions: []
+  #     MetricName: Errors
+  #     Namespace: AWS/Lambda
+  #     Statistic: Sum
+  #     Dimensions:
+  #       - Name: Resource
+  #         Value: !Sub "${AWS::StackName}-PartialNameMatchFunction:live"
+  #       - Name: ExecutedVersion
+  #         Value: !Sub PartialNameMatchFunction.Version.Version
+  #     Period: 60
+  #     EvaluationPeriods: 1
+  #     Threshold: 1
+  #     ComparisonOperator: GreaterThanThreshold
+  #     TreatMissingData: notBreaching
 
   PartialNameMatchConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
    - Added LambdaCanaryDeployment preference on updated the pipeline
    - Added Code Deploy Service role to allow code deploy
    - Set LambdaDeploymentPreference to AllAAatOnce
    - Updated lambda functions with the canary deployment configurations
    - Added additional alarms for Lambda errors and 5xx errors with lower threshold

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes
- Implement Lambda canary deployment for BAV CRI 
### What changed
- Implement Lambda canary deployment for BAV CRI 
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1098](https://govukverify.atlassian.net/browse/KIWI-1098)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

<img width="1426" alt="Screenshot 2024-09-10 at 16 39 12" src="https://github.com/user-attachments/assets/c850a62c-53a4-49b1-ac03-870c6795ca0f">

![Screenshot 2024-09-11 at 14 29 26](https://github.com/user-attachments/assets/d5bf67ef-0061-4ce7-bdf0-c722e98f5d3b)



[KIWI-1098]: https://govukverify.atlassian.net/browse/KIWI-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ