### PR TITLE
Kiwi | BE | Add max length validation to name fields within the API Spec

### DIFF
--- a/deploy/bav-spec.yaml
+++ b/deploy/bav-spec.yaml
@@ -1037,12 +1037,15 @@ components:
       properties:
         sort_code:
           type: string
-          pattern: ^[0-9]{6}$
+          pattern: ^\d{6}$|^\d{2}-\d{2}-\d{2}$|^\d{2} \d{2} \d{2}$
+          maxLength: 6
           example: "000000"
           description: 6 digit sort code
         account_number:
           type: string
-          pattern: ^[0-9]{6,8}$
+          pattern: ^\d+$
+          minLength: 6
+          maxLength: 8
           example: "12345678"
           description: bank account number
     OAuthErrorResponse:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
[KIWI-1987] Add max length validation to name fields within the API Spec

- Added maxlength validation to the Account Number and Sort Code fields in BAV, ensuring input does not exceed the required length limits.

- Implemented numeric-only validation for the Account Number and Sort Code fields in the BAV API spec, restricting input to numeric characters only.

- Ensured that all validations for these fields match the frontend.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

### Evidence

<img width="400" alt="invalid_length-validation" src="https://github.com/user-attachments/assets/4725196c-7387-406a-9558-492863be01fa">


Uploading invalid_length-sortcode-BAV.mov…


Uploading invalid_chars-sortcode.mov…











[KIWI-1987]: https://govukverify.atlassian.net/browse/KIWI-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ