### PR TITLE
KIWI-1960: Removed trailing commas and readded date of birth. Updated surname to match examples in spec

### DIFF
--- a/src/services/ExperianService.ts
+++ b/src/services/ExperianService.ts
@@ -46,13 +46,14 @@ export class ExperianService {
     	experianTokenUrl: string,
     ): Promise<any> {
     	try {
+    		/* eslint-disable */
     		const params = {
     			header: {
 				  requestType: Constants.EXPERIAN_PRODUCT_NAME,
 				  clientReferenceId: uuid,
 				  expRequestId: "",
 				  messageTime: new Date().toISOString(),
-				  options: {},
+				  options: {}
     			},
     			payload: {
 				  source: "WEB",
@@ -61,9 +62,9 @@ export class ExperianService {
 					  {
     							id: "APPLICANT_1",
     							applicantType: "APPLICANT",
-    							contactId: "MainContact_1",
-					  },
-    					],
+    							contactId: "MainContact_1"
+					  }
+    					]
 				  },
 				  contacts: [
     					{
@@ -71,23 +72,24 @@ export class ExperianService {
 					  person: {
     							typeOfPerson: "APPLICANT",
     							personDetails: {
-						  dateOfBirth: "",
+						  dateOfBirth: birthDate,
     							},
     							names: [
     								{
     									firstName: givenName,
-    									surname,
-    								},
-    							],
+    									surName: surname
+    								}
+    							]
 					  },
 					  bankAccount: {
-    							sortCode,
-    							clearAccountNumber: accountNumber,
-					  		},
-    					},
-				  ],
-    			},
+    							sortCode: sortCode,
+    							clearAccountNumber: accountNumber
+					  		}
+    					}
+				  ]
+    			}
 			  };
+			  /* eslint-enable */
 				
     		const token = await this.generateExperianToken(experianUsername, experianPassword, experianClientId, experianClientSecret, experianTokenUrl);
     		const headers = {

--- a/src/tests/unit/services/ExperianService.test.ts
+++ b/src/tests/unit/services/ExperianService.test.ts
@@ -57,12 +57,12 @@ const experianPayload = {
 	  person: {
 					typeOfPerson: "APPLICANT",
 					personDetails: {
-		  dateOfBirth: "",
+		  dateOfBirth: "DATE",
 					},
 					names: [
 		  {
 							firstName: "First",
-							surname: "Last",
+							surName: "Last",
 		  },
 					],
 	  },


### PR DESCRIPTION
## Proposed changes

### What changed

Updating json to remove trailing commas and fixing the formatting

### Why did it change

To test alignment against UAT

