### PR TITLE
BAU - NotCreateProdResource condition created

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -178,6 +178,8 @@ Conditions:
   CreateDevResources: !Equals
     - !Ref Environment
     - dev
+  NotCreateProdResources: !Not
+    - !Equals [ !Ref Environment, production ]
   IsProdLikeEnvironment: !Or
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
@@ -684,6 +686,7 @@ Resources:
 
   BAVApiBasePath:
     Type: AWS::ApiGateway::BasePathMapping
+    Condition: NotCreateProdResources
     DependsOn: "BAVApiCustomDomainName"
     Properties:
       DomainName: !Ref BAVApiCustomDomainName


### PR DESCRIPTION
Trying to recreated deleted base api mapping

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Conditional added for not creating prod resources 

### Why did it change

Drift caused by manually deleting api base mapping resource
PR to delete this resource from state
then can add it back

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
