### PR TITLE
KIWI-2082: Updating to allow STOP responses to be returned as no match

### DIFF
--- a/src/models/ISessionItem.ts
+++ b/src/models/ISessionItem.ts
@@ -44,6 +44,7 @@ export interface ISessionItem extends IBAVSession {
 	personalDetailsScore?: number;
 	experianCheckResult?: ExperianCheckResult;
 	warningsErrors?: WarningsErrors[];
+	cis?: string[];
 	vendorUuid?: string;
 	attemptCount?: number;
 }

--- a/src/models/IVeriCredential.ts
+++ b/src/models/IVeriCredential.ts
@@ -116,6 +116,7 @@ export type ExperianVerifyResponse = {
 	expRequestId: string;
 	personalDetailsScore: number;
 	warningsErrors?: WarningsErrors[];
+	outcome: string;
 };
 
 export type BankAccountInfo = {

--- a/src/services/BavService.ts
+++ b/src/services/BavService.ts
@@ -319,19 +319,18 @@ export class BavService {
 	}
 
 
-	async saveExperianCheckResult(sessionId: string, verifyResponse: ExperianVerifyResponse, experianCheckResult?: ExperianCheckResult, attemptCount?: number): Promise<void> {
+	async saveExperianCheckResult(sessionId: string, verifyResponse: ExperianVerifyResponse, experianCheckResult?: ExperianCheckResult, attemptCount?: number, cis?: string[]): Promise<void> {
 		this.logger.info({ message: `Updating ${this.tableName} table with experianCheckResult`, experianCheckResult });
 		const personalDetailsScore = verifyResponse?.personalDetailsScore;
-		const warningsErrors = verifyResponse?.warningsErrors;
 
 		const updateStateCommand = new UpdateCommand({
 			TableName: this.tableName,
 			Key: { sessionId },
-			UpdateExpression: `SET ${experianCheckResult ? "experianCheckResult = :experianCheckResult," : ""} ${personalDetailsScore ? "personalDetailsScore = :personalDetailsScore," : ""} ${ warningsErrors ? "warningsErrors = :warningsErrors," : ""} authSessionState = :authSessionState${attemptCount ? ", attemptCount = :attemptCount" : ""}`,
+			UpdateExpression: `SET ${experianCheckResult ? "experianCheckResult = :experianCheckResult," : ""} ${personalDetailsScore ? "personalDetailsScore = :personalDetailsScore," : ""} ${ cis ? "cis = :cis," : ""} authSessionState = :authSessionState${attemptCount ? ", attemptCount = :attemptCount" : ""}`,
 			ExpressionAttributeValues: {
 				...(experianCheckResult && { ":experianCheckResult": experianCheckResult }),
 				...(personalDetailsScore && { ":personalDetailsScore": personalDetailsScore }),
-				...(warningsErrors && { ":warningsErrors": warningsErrors }),
+				...(cis && { ":cis": cis }),
 				...(attemptCount && { ":attemptCount": attemptCount }),
 				":authSessionState": AuthSessionState.BAV_DATA_RECEIVED,
 			},

--- a/src/services/ExperianService.ts
+++ b/src/services/ExperianService.ts
@@ -183,7 +183,7 @@ export class ExperianService {
     	}
     }
 
-    private logRules(decisionElements: any) {
+    private logRules(decisionElements: any): void {
     	const rulesElement = decisionElements.find((object: { rules: object[] }) => object.rules);
     	const rules: Array<{ ruleId: string; ruleName: string; ruleText: string; ruleScore: number }> = rulesElement ? rulesElement?.rules : [];
     	const triggeredRules: string[] = [];
@@ -197,7 +197,7 @@ export class ExperianService {
     	this.logger.info("Triggered rules: " + JSON.stringify(triggeredRules));
     }
 
-    private logEventOutcomes(decisionElements: any) {
+    private logEventOutcomes(decisionElements: any): void {
     	const logObject = decisionElements.find((object: { auditLogs: object[] }) => object.auditLogs);
     	const eventOutcome = logObject?.auditLogs[0]?.eventOutcome;
     	this.logger.info({

--- a/src/services/VerifyAccountRequestProcessor.ts
+++ b/src/services/VerifyAccountRequestProcessor.ts
@@ -22,7 +22,7 @@ import { absoluteTimeNow } from "../utils/DateTimeUtils";
 import { APIGatewayProxyResult } from "aws-lambda";
 import { ExperianService } from "./ExperianService";
 import { ExperianCheckResults } from "../models/enums/Experian";
-import { ExperianVerifyResponse } from "../models/IVeriCredential";
+import { ExperianVerifyResponse, WarningsErrors } from "../models/IVeriCredential";
 
 export class VerifyAccountRequestProcessor {
   private static instance: VerifyAccountRequestProcessor;
@@ -189,24 +189,37 @@ export class VerifyAccountRequestProcessor {
 		  );
 		  
 		  const experianCheckResult = this.calculateExperianCheckResult(verifyResponse, session.attemptCount);
+		  const cis = this.calculateCIs(verifyResponse);
+
 		  this.logger.info(`experianCheckResult is ${experianCheckResult}`);
-	
+		  this.logger.info(`CIs generated: ${cis}`);
+
+		  this.logCis(cis, this.metrics); 
+
 		  let attemptCount;
 		  if (experianCheckResult !== ExperianCheckResults.FULL_MATCH || !experianCheckResult) {
   		if (session.attemptCount) {
-  			this.metrics.addMetric("retry-attempt-" + session.attemptCount, MetricUnits.Count, 1);
   			attemptCount = session.attemptCount + 1;
   		} else {
   			attemptCount = 1;
   		}
+  		this.metrics.addMetric("retry-attempt-" + attemptCount, MetricUnits.Count, 1);
 		  }
 
-		  await this.BavService.saveExperianCheckResult(sessionId, verifyResponse, experianCheckResult, attemptCount);
+		  await this.BavService.saveExperianCheckResult(sessionId, verifyResponse, experianCheckResult, attemptCount, cis);
 		  return Response(HttpCodesEnum.OK, JSON.stringify({
 			  message: "Success",
 			  attemptCount,
 		  }));
 	  }
+
+  private logCis(cis: string[] | undefined, metrics: Metrics) {
+	if (cis) {
+		cis.forEach(function (ci): void {
+			metrics.addMetric("ci-" + ci, MetricUnits.Count, 1);
+		});
+	}
+  }
 
   // eslint-disable-next-line max-lines-per-function, complexity
   async processHmrcRequest(sessionId: string, body: VerifyAccountPayload, clientIpAddress: string, encodedHeader: string, HMRC_TOKEN: string): Promise<APIGatewayProxyResult> {
@@ -343,13 +356,41 @@ export class VerifyAccountRequestProcessor {
 
   calculateExperianCheckResult(verifyResponse: ExperianVerifyResponse, attemptCount?: number): ExperianCheckResult {
   	const personalDetailsScore = verifyResponse?.personalDetailsScore;
-  	if (personalDetailsScore === 9 && !this.isCriticalResponseCode(verifyResponse, this.metrics)) {
-  		return ExperianCheckResults.FULL_MATCH;
-  	} else if (personalDetailsScore !== 9 && attemptCount === undefined) {
+  	if (verifyResponse?.outcome === "STOP" && attemptCount === undefined) {
   		return undefined;
-  	} else {
-  		return ExperianCheckResults.NO_MATCH;
   	}
+  	if (personalDetailsScore !== 9 && attemptCount === undefined) {
+  		return undefined;
+  	}
+  	if (personalDetailsScore === 9 && !this.isCriticalResponseCode(verifyResponse, this.metrics) && verifyResponse?.outcome !== "STOP") {
+  		return ExperianCheckResults.FULL_MATCH;
+  	}
+
+  	return ExperianCheckResults.NO_MATCH;
+  }
+
+  calculateCIs(verifyResponse: ExperianVerifyResponse): string[] | undefined {
+  	const warningsErrors: WarningsErrors[] | undefined = verifyResponse?.warningsErrors;
+  	let cisRequired: string[] = [];
+
+  	const criticalErrors = ["6", "7", "11", "12"];
+  	const warningError  = verifyResponse?.warningsErrors;
+  	if (warningError) {
+  		warningError.forEach(function (value): void {
+  			if (value?.responseType === "error") {
+  				if (criticalErrors.includes(value.responseCode)) {
+  					cisRequired.push("D15");
+  				}
+  			}
+  		}); 
+  	}
+
+  	if (verifyResponse.outcome === "STOP") {
+  		cisRequired.push("D15");
+  	}
+	
+  	cisRequired = [...new Set(cisRequired)];
+  	return cisRequired.length === 0 ? undefined : cisRequired;;
   }
 
   isCriticalResponseCode(verifyResponse: ExperianVerifyResponse, metrics: Metrics): boolean {

--- a/src/services/VerifyAccountRequestProcessor.ts
+++ b/src/services/VerifyAccountRequestProcessor.ts
@@ -22,7 +22,7 @@ import { absoluteTimeNow } from "../utils/DateTimeUtils";
 import { APIGatewayProxyResult } from "aws-lambda";
 import { ExperianService } from "./ExperianService";
 import { ExperianCheckResults } from "../models/enums/Experian";
-import { ExperianVerifyResponse, WarningsErrors } from "../models/IVeriCredential";
+import { ExperianVerifyResponse } from "../models/IVeriCredential";
 
 export class VerifyAccountRequestProcessor {
   private static instance: VerifyAccountRequestProcessor;
@@ -213,12 +213,12 @@ export class VerifyAccountRequestProcessor {
 		  }));
 	  }
 
-  private logCis(cis: string[] | undefined, metrics: Metrics) {
-	if (cis) {
-		cis.forEach(function (ci): void {
-			metrics.addMetric("ci-" + ci, MetricUnits.Count, 1);
-		});
-	}
+  private logCis(cis: string[] | undefined, metrics: Metrics): void {
+  	if (cis) {
+  		cis.forEach(function (ci): void {
+  			metrics.addMetric("ci-" + ci, MetricUnits.Count, 1);
+  		});
+  	}
   }
 
   // eslint-disable-next-line max-lines-per-function, complexity
@@ -370,7 +370,6 @@ export class VerifyAccountRequestProcessor {
   }
 
   calculateCIs(verifyResponse: ExperianVerifyResponse): string[] | undefined {
-  	const warningsErrors: WarningsErrors[] | undefined = verifyResponse?.warningsErrors;
   	let cisRequired: string[] = [];
 
   	const criticalErrors = ["6", "7", "11", "12"];
@@ -390,7 +389,7 @@ export class VerifyAccountRequestProcessor {
   	}
 	
   	cisRequired = [...new Set(cisRequired)];
-  	return cisRequired.length === 0 ? undefined : cisRequired;;
+  	return cisRequired.length === 0 ? undefined : cisRequired;
   }
 
   isCriticalResponseCode(verifyResponse: ExperianVerifyResponse, metrics: Metrics): boolean {

--- a/src/tests/unit/services/BavService.test.ts
+++ b/src/tests/unit/services/BavService.test.ts
@@ -532,7 +532,7 @@ describe("BAV Service", () => {
 		it("saves account information to dynamo", async () => {
 			mockDynamoDbClient.send = jest.fn().mockResolvedValue({});
 
-			await bavService.saveExperianCheckResult(sessionId, { expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined }, experianCheckResultFullMatch, 1);
+			await bavService.saveExperianCheckResult(sessionId, { expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined, outcome: "CONTINUE" }, experianCheckResultFullMatch, 1);
 
 			expect(UpdateCommand).toHaveBeenCalledWith({
 				TableName: tableName,
@@ -550,7 +550,7 @@ describe("BAV Service", () => {
 		it("saves account information to dynamo without attemptCount", async () => {
 			mockDynamoDbClient.send = jest.fn().mockResolvedValue({});
 
-			await bavService.saveExperianCheckResult(sessionId, { expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined }, experianCheckResultFullMatch, undefined);
+			await bavService.saveExperianCheckResult(sessionId, { expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined, outcome: "continue" }, experianCheckResultFullMatch, undefined);
 
 			expect(UpdateCommand).toHaveBeenCalledWith({
 				TableName: tableName,
@@ -567,16 +567,15 @@ describe("BAV Service", () => {
 		it("saves account information to dynamo with responseCode if present", async () => {
 			mockDynamoDbClient.send = jest.fn().mockResolvedValue({});
 
-			await bavService.saveExperianCheckResult(sessionId, { expRequestId: "1234568", personalDetailsScore: 1, warningsErrors: warningsError2 }, experianCheckResultNoMatch, 1);
+			await bavService.saveExperianCheckResult(sessionId, { expRequestId: "1234568", personalDetailsScore: 1, warningsErrors: warningsError2, outcome: "REFER" }, experianCheckResultNoMatch, 1);
 
 			expect(UpdateCommand).toHaveBeenCalledWith({
 				TableName: tableName,
 				Key: { sessionId },
-				UpdateExpression: "SET experianCheckResult = :experianCheckResult, personalDetailsScore = :personalDetailsScore, warningsErrors = :warningsErrors, authSessionState = :authSessionState, attemptCount = :attemptCount",
+				UpdateExpression: "SET experianCheckResult = :experianCheckResult, personalDetailsScore = :personalDetailsScore,  authSessionState = :authSessionState, attemptCount = :attemptCount",
 				ExpressionAttributeValues: {
 					":experianCheckResult": experianCheckResultNoMatch,
 					":personalDetailsScore": 1,
-					":warningsErrors": warningsError2,
 					":authSessionState": AuthSessionState.BAV_DATA_RECEIVED,
 					":attemptCount": 1,
 				},
@@ -586,7 +585,7 @@ describe("BAV Service", () => {
 		it("returns an error when account information cannot be saved to dynamo", async () => {
 			mockDynamoDbClient.send = jest.fn().mockRejectedValueOnce("Error!");
 
-			await expect(bavService.saveExperianCheckResult(sessionId, { expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined }, experianCheckResultFullMatch, undefined)).rejects.toThrow(expect.objectContaining({
+			await expect(bavService.saveExperianCheckResult(sessionId, { expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined, outcome: "CONTINUE" }, experianCheckResultFullMatch, undefined)).rejects.toThrow(expect.objectContaining({
 				statusCode: HttpCodesEnum.SERVER_ERROR,
 				message: "saveExperianCheckResult failed: got error saving experianCheckResult",
 			}));

--- a/src/tests/unit/services/ExperianService.test.ts
+++ b/src/tests/unit/services/ExperianService.test.ts
@@ -167,7 +167,7 @@ describe("Experian service", () => {
 				eventOutcome: experianVerifyResponse.clientResponsePayload.decisionElements[1].auditLogs![0].eventOutcome,
 			});
 			expect(logger.info).toHaveBeenNthCalledWith(11, "Triggered rules: [\"Rule Id: CNS1018, Rule Name: BAV_OA_GE90D_PDSGE7_ASGE6 , Rule text: Match to an open account, aged >=90 days, Personal Details Score >=7 and Address Score >=6\",\"Rule Id: CNS1019, Rule Name: BAV_OA_GE90D_PDSGE5_ASGE4 , Rule text: Match found to an open account which was opened 90 or more days ago with Personal Details Score >= 5 and Address Score >= 4\",\"Rule Id: CNS1020, Rule Name: BAV_OA_PDSGE5_ASGE4 , Rule text: Match to an open account, aged >=90 days, Personal Details Score >=5 and Address Score >=4\",\"Rule Id: CNS1022, Rule Name: BAV_OA_GE90D_PDSGE5 , Rule text: Match to an open account, aged >=90 days, Personal Details Score >=5\"]");
-			expect(response).toEqual({ "personalDetailsScore": 9, "expRequestId": "1234567890", "warningsErrors":[] });
+			expect(response).toEqual({ "personalDetailsScore": 9, "expRequestId": "1234567890", "warningsErrors":[], outcome: "CONTINUE" });
 			
 			expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "Experian-CONTINUE", "Count", 1);
 			expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "Experian-Match_Found", "Count", 1);
@@ -217,7 +217,7 @@ describe("Experian service", () => {
 				eventOutcome: undefined,
 			});
 			expect(logger.info).toHaveBeenNthCalledWith(11, "Triggered rules: [\"Rule Id: CNS1018, Rule Name: BAV_OA_GE90D_PDSGE7_ASGE6 , Rule text: Match to an open account, aged >=90 days, Personal Details Score >=7 and Address Score >=6\",\"Rule Id: CNS1019, Rule Name: BAV_OA_GE90D_PDSGE5_ASGE4 , Rule text: Match found to an open account which was opened 90 or more days ago with Personal Details Score >= 5 and Address Score >= 4\",\"Rule Id: CNS1020, Rule Name: BAV_OA_PDSGE5_ASGE4 , Rule text: Match to an open account, aged >=90 days, Personal Details Score >=5 and Address Score >=4\",\"Rule Id: CNS1022, Rule Name: BAV_OA_GE90D_PDSGE5 , Rule text: Match to an open account, aged >=90 days, Personal Details Score >=5\"]");
-			expect(response).toEqual({ "personalDetailsScore": undefined, "expRequestId": "1234567890", "warningsErrors":[] });
+			expect(response).toEqual({ "personalDetailsScore": undefined, "expRequestId": "1234567890", "warningsErrors":[], outcome: "CONTINUE" });
 		});
 
 		it.each([
@@ -235,7 +235,7 @@ describe("Experian service", () => {
 				experianVerifyUrl,
 				experianTokenUrl);
 		
-			expect(response).toEqual({ "expRequestId": "1234567890", "personalDetailsScore": 1, "warningsErrors": [{ responseCode, "responseMessage": expectedMessage, "responseType": "warning" }] });
+			expect(response).toEqual({ "expRequestId": "1234567890", "personalDetailsScore": 1, "warningsErrors": [{ responseCode, "responseMessage": expectedMessage, "responseType": "warning" }], outcome: "STOP" });
 		  });
 
 		it.each([

--- a/src/tests/unit/services/ExperianService.test.ts
+++ b/src/tests/unit/services/ExperianService.test.ts
@@ -108,7 +108,10 @@ process.env.THIRDPARTY_DIRECT_SUBMISSION = "false";
 
 describe("Experian service", () => {
 	
-	beforeAll(() => {
+	beforeEach(() => {
+		
+		metrics.singleMetric.calledWith().mockReturnValue(metrics);
+
 		process.env.LOG_THIRDPARTY_API_RESPONSE = "false";
 		experianServiceTest = new ExperianService(logger, metrics, 2, mockDynamoDbClient, experianTokenTableName);
 	});

--- a/src/tests/unit/services/VerifiableCredentialService.test.ts
+++ b/src/tests/unit/services/VerifiableCredentialService.test.ts
@@ -127,7 +127,7 @@ describe("VerifiableCredentialService", () => {
 		});
 
 		it("should return a failure evidence block correctly", () => {
-			const evidenceBlock = service.getFailureEvidenceBlock(vendorUuid, true);
+			const evidenceBlock = service.getFailureEvidenceBlock(vendorUuid, ["D15"]);
 			expect(evidenceBlock).toEqual(expect.objectContaining({
 				txn: vendorUuid,
 				strengthScore: 3,
@@ -156,6 +156,7 @@ describe("VerifiableCredentialService", () => {
 
 		it("should generate a signed JWT with failure evidence including a CI for a failed match result", async () => {
 			mockSessionItem.experianCheckResult = ExperianCheckResult.NO_MATCH;
+			mockSessionItem.cis = ["D15"];
 			const signedJWT = "mockSignedJwt";
 			mockKmsJwtAdapter.sign.mockResolvedValue(signedJWT);
 

--- a/src/tests/unit/services/VerifiableCredentialService.test.ts
+++ b/src/tests/unit/services/VerifiableCredentialService.test.ts
@@ -77,7 +77,7 @@ const failureBlock = {
 		},
 	],
 	ci: [
-		"D15",
+		"dummyCi",
 	],
 };
 
@@ -99,7 +99,6 @@ describe("VerifiableCredentialService", () => {
 	let service: VerifiableCredentialService;
 
 	beforeEach(() => {
-		jest.clearAllMocks();
 		service = new VerifiableCredentialService( mockKmsJwtAdapter, mockIssuer, mockLogger, dnsSuffix, credentialVendorExperian);
 	});
 
@@ -127,12 +126,12 @@ describe("VerifiableCredentialService", () => {
 		});
 
 		it("should return a failure evidence block correctly", () => {
-			const evidenceBlock = service.getFailureEvidenceBlock(vendorUuid, ["D15"]);
+			const evidenceBlock = service.getFailureEvidenceBlock(vendorUuid, ["dummyCi"]);
 			expect(evidenceBlock).toEqual(expect.objectContaining({
 				txn: vendorUuid,
 				strengthScore: 3,
 				validityScore: 0,
-				ci: expect.arrayContaining(["D15"]),
+				ci: expect.arrayContaining(["dummyCi"]),
 			}));
 		});
 	});
@@ -156,7 +155,7 @@ describe("VerifiableCredentialService", () => {
 
 		it("should generate a signed JWT with failure evidence including a CI for a failed match result", async () => {
 			mockSessionItem.experianCheckResult = ExperianCheckResult.NO_MATCH;
-			mockSessionItem.cis = ["D15"];
+			mockSessionItem.cis = ["dummyCi"];
 			const signedJWT = "mockSignedJwt";
 			mockKmsJwtAdapter.sign.mockResolvedValue(signedJWT);
 

--- a/src/tests/unit/services/VerifyAccountRequestProcessorExperian.test.ts
+++ b/src/tests/unit/services/VerifyAccountRequestProcessorExperian.test.ts
@@ -31,8 +31,8 @@ const verifyAccountPayload = {
 	sort_code: "123456",
 	account_number: "12345678",
 };
-const experianServiceVerifyResponseSuccess = { personalDetailsScore: 9, expRequestId: "1234568" };
-const experianServiceVerifyResponseFail = { personalDetailsScore: 1, expRequestId: "1234568" };
+const experianServiceVerifyResponseSuccess = { personalDetailsScore: 9, expRequestId: "1234568", outcome: "CONTINUE" };
+const experianServiceVerifyResponseFail = { personalDetailsScore: 1, expRequestId: "1234568", outcome: "REFER" };
 const clientIpAddress = "127.0.0.1";
 const person: PersonIdentityItem = {
 	sessionId,
@@ -328,7 +328,7 @@ describe("VerifyAccountRequestProcessor", () => {
 				ssmParams,
 			);
 
-			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith(sessionId, { expRequestId: "1234568", personalDetailsScore: 9 }, ExperianCheckResults.FULL_MATCH, undefined);
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith(sessionId, { expRequestId: "1234568", personalDetailsScore: 9, outcome: "CONTINUE" }, ExperianCheckResults.FULL_MATCH, undefined, undefined);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			expect(response.body).toBe(JSON.stringify({ message:"Success" }));
 		});
@@ -346,7 +346,7 @@ describe("VerifyAccountRequestProcessor", () => {
 				ssmParams,
 			);
 
-			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith(sessionId, { expRequestId: "1234568", personalDetailsScore: 1 }, undefined, 1);
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith(sessionId, { expRequestId: "1234568", personalDetailsScore: 1, outcome: "REFER" }, undefined, 1, undefined);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			expect(response.body).toBe(JSON.stringify({ message:"Success", attemptCount: 1 }));
 		});
@@ -371,7 +371,7 @@ describe("VerifyAccountRequestProcessor", () => {
 				ssmParams,
 			);
 
-			expect(mockBavService.saveExperianCheckResult).toHaveBeenNthCalledWith(2, sessionId, { expRequestId: "1234568", personalDetailsScore: 1 }, "NO_MATCH", 2);
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenNthCalledWith(2, sessionId, { expRequestId: "1234568", personalDetailsScore: 1, outcome: "REFER" }, "NO_MATCH", 2, undefined);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			expect(response.body).toBe(JSON.stringify({ message:"Success", attemptCount: 2 }));
 		});
@@ -379,7 +379,8 @@ describe("VerifyAccountRequestProcessor", () => {
 		it("returns success without attemptCount when there has been a FULL_MATCH", async () => {
 			mockBavService.getPersonIdentityById.mockResolvedValueOnce(person);
 			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, attemptCount: undefined });
-			mockExperianService.verify.mockResolvedValueOnce({ expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined });
+			mockExperianService.verify.mockResolvedValueOnce({ expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined, outcome: "CONTINUE" 
+			});
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
 				sessionId, 
@@ -404,7 +405,7 @@ describe("VerifyAccountRequestProcessor", () => {
 			["NO_MATCH", "11", "error"],
 			["NO_MATCH", "12", "error"],
 
-		  ])("returns success with a %i provided a response code of %i and type %i is returned", async (matchResult, responseCode, responseType) => {
+		  ])("returns success with a %s provided a response code of %i and type %s is returned", async (matchResult, responseCode, responseType) => {
 			mockBavService.getPersonIdentityById.mockResolvedValueOnce(person);
 			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, attemptCount: undefined });
 			mockExperianService.verify.mockResolvedValueOnce({ expRequestId: "1234568",
@@ -413,7 +414,9 @@ describe("VerifyAccountRequestProcessor", () => {
 					responseCode,
 					responseType,
 					responseMessage: "Should not proceed",
-				}] });
+				}],
+				outcome: "REFER"
+			 });
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
 				sessionId, 
@@ -424,8 +427,8 @@ describe("VerifyAccountRequestProcessor", () => {
 			);
 
 			const attemptCount = matchResult === "FULL_MATCH" ? undefined : 1;
-
-			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 9, "warningsErrors": [{ responseCode, "responseMessage": "Should not proceed", responseType }] }, matchResult, attemptCount);
+			const cis = responseType === "error" && (responseCode === "6" || responseCode === "7" || responseCode === "11" || responseCode === "12") ? ["D15"] : undefined
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 9, "warningsErrors": [{ responseCode, "responseMessage": "Should not proceed", responseType }], "outcome": "REFER" }, matchResult, attemptCount, cis);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			if (attemptCount === 1) {
 				expect(response.body).toBe(JSON.stringify({ message:"Success", attemptCount: 1 })); // eslint-disable-line
@@ -443,7 +446,9 @@ describe("VerifyAccountRequestProcessor", () => {
 					responseCode: "1",
 					responseType: "error",
 					responseMessage: "Should proceed",
-				}] });
+				}],
+				outcome: "REFER" 
+			 });
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
 				sessionId, 
@@ -453,7 +458,7 @@ describe("VerifyAccountRequestProcessor", () => {
 				ssmParams,
 			);
 
-			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 9, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }] }, "FULL_MATCH", undefined);
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 9, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }], "outcome": "REFER" }, "FULL_MATCH", undefined, undefined);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			expect(response.body).toBe(JSON.stringify({ message:"Success" }));
 		});
@@ -461,13 +466,17 @@ describe("VerifyAccountRequestProcessor", () => {
 		it("returns success with attemptCount and NO_MATCH when personalDetails score is less than 9 and code is not on excluded list and user is on second attempt", async () => {
 			mockBavService.getPersonIdentityById.mockResolvedValueOnce(person);
 			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, attemptCount: 1 });
-			mockExperianService.verify.mockResolvedValueOnce({ expRequestId: "1234568",
+			mockExperianService.verify.mockResolvedValueOnce(
+				{
+				expRequestId: "1234568",
 				personalDetailsScore: 7,
 				warningsErrors: [{
 					responseCode: "1",
 					responseType: "error",
 					responseMessage: "Should proceed",
-				}] });
+				}],
+				outcome: "REFER" 
+			});
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
 				sessionId, 
@@ -477,7 +486,35 @@ describe("VerifyAccountRequestProcessor", () => {
 				ssmParams,
 			);
 
-			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 7, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }] }, "NO_MATCH", 2);
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 7, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }], "outcome": "REFER"}, "NO_MATCH", 2, undefined);
+			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
+			expect(response.body).toBe(JSON.stringify({ message:"Success", attemptCount: 2 }));
+		});
+
+		it("returns success with attemptCount and NO_MATCH when when a STOP is received regardless of scores", async () => {
+			mockBavService.getPersonIdentityById.mockResolvedValueOnce(person);
+			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, attemptCount: 1 });
+			mockExperianService.verify.mockResolvedValueOnce(
+				{
+				expRequestId: "1234568",
+				personalDetailsScore: 9,
+				warningsErrors: [{
+					responseCode: "1",
+					responseType: "error",
+					responseMessage: "Should proceed",
+				}],
+				outcome: "STOP" 
+			});
+
+			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
+				sessionId, 
+				verifyAccountPayload, 
+				clientIpAddress, 
+				encodedTxmaHeader,
+				ssmParams,
+			);
+
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 9, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }], "outcome": "STOP"}, "NO_MATCH", 2, ["D15"]);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			expect(response.body).toBe(JSON.stringify({ message:"Success", attemptCount: 2 }));
 		});

--- a/src/tests/unit/services/VerifyAccountRequestProcessorExperian.test.ts
+++ b/src/tests/unit/services/VerifyAccountRequestProcessorExperian.test.ts
@@ -379,7 +379,7 @@ describe("VerifyAccountRequestProcessor", () => {
 		it("returns success without attemptCount when there has been a FULL_MATCH", async () => {
 			mockBavService.getPersonIdentityById.mockResolvedValueOnce(person);
 			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, attemptCount: undefined });
-			mockExperianService.verify.mockResolvedValueOnce({ expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined, outcome: "CONTINUE" 
+			mockExperianService.verify.mockResolvedValueOnce({ expRequestId: "1234568", personalDetailsScore: 9, warningsErrors: undefined, outcome: "CONTINUE", 
 			});
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
@@ -415,7 +415,7 @@ describe("VerifyAccountRequestProcessor", () => {
 					responseType,
 					responseMessage: "Should not proceed",
 				}],
-				outcome: "REFER"
+				outcome: "REFER",
 			 });
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
@@ -427,7 +427,7 @@ describe("VerifyAccountRequestProcessor", () => {
 			);
 
 			const attemptCount = matchResult === "FULL_MATCH" ? undefined : 1;
-			const cis = responseType === "error" && (responseCode === "6" || responseCode === "7" || responseCode === "11" || responseCode === "12") ? ["D15"] : undefined
+			const cis = responseType === "error" && (responseCode === "6" || responseCode === "7" || responseCode === "11" || responseCode === "12") ? ["D15"] : undefined;
 			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 9, "warningsErrors": [{ responseCode, "responseMessage": "Should not proceed", responseType }], "outcome": "REFER" }, matchResult, attemptCount, cis);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			if (attemptCount === 1) {
@@ -447,7 +447,7 @@ describe("VerifyAccountRequestProcessor", () => {
 					responseType: "error",
 					responseMessage: "Should proceed",
 				}],
-				outcome: "REFER" 
+				outcome: "REFER", 
 			 });
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
@@ -468,15 +468,15 @@ describe("VerifyAccountRequestProcessor", () => {
 			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, attemptCount: 1 });
 			mockExperianService.verify.mockResolvedValueOnce(
 				{
-				expRequestId: "1234568",
-				personalDetailsScore: 7,
-				warningsErrors: [{
-					responseCode: "1",
-					responseType: "error",
-					responseMessage: "Should proceed",
-				}],
-				outcome: "REFER" 
-			});
+					expRequestId: "1234568",
+					personalDetailsScore: 7,
+					warningsErrors: [{
+						responseCode: "1",
+						responseType: "error",
+						responseMessage: "Should proceed",
+					}],
+					outcome: "REFER", 
+				});
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
 				sessionId, 
@@ -486,7 +486,7 @@ describe("VerifyAccountRequestProcessor", () => {
 				ssmParams,
 			);
 
-			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 7, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }], "outcome": "REFER"}, "NO_MATCH", 2, undefined);
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 7, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }], "outcome": "REFER" }, "NO_MATCH", 2, undefined);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			expect(response.body).toBe(JSON.stringify({ message:"Success", attemptCount: 2 }));
 		});
@@ -496,15 +496,15 @@ describe("VerifyAccountRequestProcessor", () => {
 			mockBavService.getSessionById.mockResolvedValueOnce({ ...session, attemptCount: 1 });
 			mockExperianService.verify.mockResolvedValueOnce(
 				{
-				expRequestId: "1234568",
-				personalDetailsScore: 9,
-				warningsErrors: [{
-					responseCode: "1",
-					responseType: "error",
-					responseMessage: "Should proceed",
-				}],
-				outcome: "STOP" 
-			});
+					expRequestId: "1234568",
+					personalDetailsScore: 9,
+					warningsErrors: [{
+						responseCode: "1",
+						responseType: "error",
+						responseMessage: "Should proceed",
+					}],
+					outcome: "STOP", 
+				});
 
 			const response = await verifyAccountRequestProcessorTest.processExperianRequest(
 				sessionId, 
@@ -514,7 +514,7 @@ describe("VerifyAccountRequestProcessor", () => {
 				ssmParams,
 			);
 
-			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 9, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }], "outcome": "STOP"}, "NO_MATCH", 2, ["D15"]);
+			expect(mockBavService.saveExperianCheckResult).toHaveBeenCalledWith("SESSIONID", { "expRequestId": "1234568", "personalDetailsScore": 9, "warningsErrors": [{ "responseCode": "1", "responseMessage": "Should proceed", "responseType": "error" }], "outcome": "STOP" }, "NO_MATCH", 2, ["D15"]);
 			expect(response.statusCode).toEqual(HttpCodesEnum.OK);
 			expect(response.body).toBe(JSON.stringify({ message:"Success", attemptCount: 2 }));
 		});

--- a/src/utils/LogResponseCode.ts
+++ b/src/utils/LogResponseCode.ts
@@ -2,10 +2,12 @@ import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 
 export const logResponseCode = (warningsErrors: Array<{ responseType: string; responseCode: string; responseMessage: string }>, logger: any, metrics: Metrics): any => {
 
-	if (warningsErrors) {
+	if (warningsErrors && warningsErrors.length > 0) {
+		const responseCodeMetric = metrics.singleMetric();
 		warningsErrors.forEach((warningError) => {
 			logger.info(`Response code: ${warningError?.responseCode}, Response message: ${warningError?.responseMessage}`);
-			metrics.addMetric("Response-Code-" + warningError?.responseCode, MetricUnits.Count, 1);
-	  });
+			responseCodeMetric.addDimension("experian-response-code", warningError?.responseCode);
+		});
+		responseCodeMetric.addMetric("ResponseCodes", MetricUnits.Count, 1); 
 	}
 };


### PR DESCRIPTION
## Proposed changes

### What changed

Added logic to treat STOP requests as a no match.
Refactored scoring logic to remove it from the user info handlers.
Updated tests
Added outcome to the verify response to make this easier to manage in future

### Why did it change

To block users who receive a stop from Experian
To allow us to more easily understand and update scoring logic.


