### PR TITLE
KIWI-2082: Removing ci mapping logic from credential creation

### DIFF
--- a/src/models/ISessionItem.ts
+++ b/src/models/ISessionItem.ts
@@ -43,7 +43,6 @@ export interface ISessionItem extends IBAVSession {
 	copCheckResult?: CopCheckResult;
 	personalDetailsScore?: number;
 	experianCheckResult?: ExperianCheckResult;
-	warningsErrors?: WarningsErrors[];
 	cis?: string[];
 	vendorUuid?: string;
 	attemptCount?: number;

--- a/src/services/VerifiableCredentialService.ts
+++ b/src/services/VerifiableCredentialService.ts
@@ -77,21 +77,7 @@ export class VerifiableCredentialService {
 		const subject = sessionItem.subject;
 		const experianResultIsMatch = sessionItem.experianCheckResult === ExperianCheckResult.FULL_MATCH;
 
-		let cis = sessionItem?.cis;
-
-		// To be removed
-		if (cis === undefined && !experianResultIsMatch) {
-			const ci = process.env.USE_MOCKED ? mockCI : ["D15"];
-			cis = experianResultIsMatch ? undefined : ci;
-		}
-
-		if (sessionItem.warningsErrors) {
-			sessionItem.warningsErrors.forEach((item) => {
-				if (item.responseCode === "2" || item.responseCode === "3") {
-					cis = undefined;
-				}
-			});
-		}
+		const cis = sessionItem?.cis;
 
 		const evidenceInfo = experianResultIsMatch ?
 			this.getSuccessEvidenceBlock(sessionItem.vendorUuid!) : this.getFailureEvidenceBlock(sessionItem.vendorUuid!, cis);

--- a/src/services/VerifyAccountRequestProcessor.ts
+++ b/src/services/VerifyAccountRequestProcessor.ts
@@ -23,6 +23,7 @@ import { APIGatewayProxyResult } from "aws-lambda";
 import { ExperianService } from "./ExperianService";
 import { ExperianCheckResults } from "../models/enums/Experian";
 import { ExperianVerifyResponse } from "../models/IVeriCredential";
+import { mockCI } from "../tests/contract/mocks/VerifiableCredential";
 
 export class VerifyAccountRequestProcessor {
   private static instance: VerifyAccountRequestProcessor;
@@ -371,6 +372,7 @@ export class VerifyAccountRequestProcessor {
 
   calculateCIs(verifyResponse: ExperianVerifyResponse): string[] | undefined {
   	let cisRequired: string[] = [];
+  	const ci = process.env.USE_MOCKED ? mockCI[0] : "D15";
 
   	const criticalErrors = ["6", "7", "11", "12"];
   	const warningError  = verifyResponse?.warningsErrors;
@@ -378,14 +380,14 @@ export class VerifyAccountRequestProcessor {
   		warningError.forEach(function (value): void {
   			if (value?.responseType === "error") {
   				if (criticalErrors.includes(value.responseCode)) {
-  					cisRequired.push("D15");
+  					cisRequired.push(ci);
   				}
   			}
   		}); 
   	}
 
   	if (verifyResponse.outcome === "STOP") {
-  		cisRequired.push("D15");
+  		cisRequired.push(ci);
   	}
 	
   	cisRequired = [...new Set(cisRequired)];

--- a/src/tests/contract/data/session-items.json
+++ b/src/tests/contract/data/session-items.json
@@ -140,9 +140,13 @@
               },
               "subject": {
                 "S": "test-subject"
-              }
-            }
+              },
+              "cis": {
+                "L": [{
+                      "S": "dummyCi"
+              }]}
         }
-    }        
-    ]
+    }
+  }        
+]
 }

--- a/src/tests/unit/services/UserInfoRequestProcessor.test.ts
+++ b/src/tests/unit/services/UserInfoRequestProcessor.test.ts
@@ -215,11 +215,7 @@ describe("UserInfoRequestProcessor", () => {
 		mockBavService.getSessionById.mockResolvedValue(mockSession);
 		mockSession.personalDetailsScore = 9;
 		mockSession.experianCheckResult = "NO_MATCH";
-		mockSession.warningsErrors = [{	
-			responseType: "warning",
-			responseCode: "2",
-			responseMessage: "Modulus check algorithm is unavailable for these account details",
-		}];
+
 		mockBavService.getPersonIdentityBySessionId.mockResolvedValue(mockPerson);
 		// @ts-ignore
 		userInforequestProcessorTest.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();

--- a/src/tests/unit/services/VerifiableCredentialService.test.ts
+++ b/src/tests/unit/services/VerifiableCredentialService.test.ts
@@ -170,12 +170,7 @@ describe("VerifiableCredentialService", () => {
 
 		it("should generate a signed JWT with failure evidence without a CI for a failed match result with response code 2 or 3", async () => {
 			mockSessionItem.experianCheckResult = ExperianCheckResult.NO_MATCH;
-			mockSessionItem.warningsErrors = 
-				[{ 	
-					responseType: "warning",
-					responseCode: "2",
-					responseMessage: "Modulus check algorithm is unavailable for these account details",
-				}];
+			mockSessionItem.cis = undefined;
 			const signedJWT = "mockSignedJwt";
 			mockKmsJwtAdapter.sign.mockResolvedValue(signedJWT);
 


### PR DESCRIPTION
## Proposed changes

### What changed

Removed mapping logic from the credential creation

### Why did it change

To make it easier to amend and update mapping logic

