### PR TITLE
KIWI-1978: Added the client config to the verify function so it can be used for selecting the required url

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -161,8 +161,8 @@ Mappings:
               "jwksEndpoint":"https://api.identity.staging.account.gov.uk/.well-known/jwks.json",
               "clientId":"03A5A659-17AA-453F-B905-95D2804823D1",
               "redirectUri":"https://identity.staging.account.gov.uk/credential-issuer/callback?id=bav",
-              "experianTokenEndpoint":"https://x0ch9rvyhe.execute-api.eu-west-2.amazonaws.com/staging/services/v0/applications/3",
-              "experianVerifyEndpoint":"https://x0ch9rvyhe.execute-api.eu-west-2.amazonaws.com/staging/oauth2/experianone/v1/token"
+              "experianTokenEndpoint":"https://x0ch9rvyhe.execute-api.eu-west-2.amazonaws.com/staging/oauth2/experianone/v1/token",
+              "experianVerifyEndpoint":"https://x0ch9rvyhe.execute-api.eu-west-2.amazonaws.com/staging/services/v0/applications/3"
             }
           ]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
@@ -181,8 +181,8 @@ Mappings:
               "jwksEndpoint":"https://api.identity.integration.account.gov.uk/.well-known/jwks.json",
               "clientId":"AE140E43-1987-4EE8-86CC-BEF19FC9FF3F",
               "redirectUri":"https://identity.integration.account.gov.uk/credential-issuer/callback?id=bav",
-              "experianTokenEndpoint":"https://uk-api.experian.com/decisionanalytics/crosscore/nprxuz82vn3d/services/v0/applications/3",
-              "experianVerifyEndpoint":"https://uk-api.experian.com/oauth2/experianone/v1/token"
+              "experianTokenEndpoint":"https://uk-api.experian.com/oauth2/experianone/v1/token",
+              "experianVerifyEndpoint":"https://uk-api.experian.com/decisionanalytics/crosscore/nprxuz82vn3d/services/v0/applications/3"
             }
           ]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
@@ -201,8 +201,8 @@ Mappings:
               "jwksEndpoint":"https://api.identity.account.gov.uk/.well-known/jwks.json",
               "clientId":"C910A762-4BB2-400D-8F3D-4D7E6C84E342",
               "redirectUri":"https://identity.account.gov.uk/credential-issuer/callback?id=bav",
-              "experianTokenEndpoint":"https://uk-api.experian.com/decisionanalytics/crosscore/npfygurfzc3g/services/v0/applications/3",
-              "experianVerifyEndpoint":"https://uk-api.experian.com/oauth2/experianone/v1/token"
+              "experianTokenEndpoint":"https://uk-api.experian.com/oauth2/experianone/v1/token",
+              "experianVerifyEndpoint":"https://uk-api.experian.com/decisionanalytics/crosscore/npfygurfzc3g/services/v0/applications/3"
             }
           ]'
       AUTHSESSIONTTLSECS: 950400 # 11 days in seconds
@@ -3368,6 +3368,7 @@ Resources:
           EXPERIAN_USERNAME_SSM_PATH: !Sub "/${Environment}/bav-cri-api/CrosscoreV2/Username"
           EXPERIAN_CLIENT_ID_SSM_PATH: !Sub "/${Environment}/bav-cri-api/CrosscoreV2/clientId"
           EXPERIAN_CLIENT_SECRET_SSM_PATH: !Sub "/${Environment}/bav-cri-api/CrosscoreV2/clientSecret"
+          CLIENT_CONFIG: !FindInMap [ EnvironmentVariables, !Ref Environment, CLIENTS ]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess


### PR DESCRIPTION
## Proposed changes

### What changed

Added the the client config environment variable to the verify function

### Why did it change

To enable the test strategy to select a url in the verify function

