### PR TITLE
Update to include a custom FMS policy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -642,6 +642,7 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: !Ref Environment
+      AlwaysDeploy: true
       OpenApiVersion: 3.0.1
       AccessLogSetting:
         Format: >-


### PR DESCRIPTION

This is moving to central firewall management via FMS 

## Proposed changes

Added tags to tell FMS to use a custom webACL for this resource

### What changed
Added tags

### Why did it change
to tell FMS to use a custom webACL for this resource

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1407