### PR TITLE
IPS-1516: Create bucket for key rotation

### DIFF
--- a/infra-l2-kms/template.yaml
+++ b/infra-l2-kms/template.yaml
@@ -34,6 +34,15 @@ Parameters:
     Description: Number of days to retain KMS in pending deletion state when deleted
     Default: 30
 
+  ServiceName:
+    Type: String
+    Description: >
+      Optionally provide a service name to enable naming convention patterns
+    Default: "none"
+    AllowedPattern: "[a-z0-9-]+|none"
+    ConstraintDescription: >
+      Must be a DNS compliant name containing alphanumeric characters and hyphens only OR set as "none"
+
 Conditions:
   UseCodeSigning:
     Fn::Not:
@@ -127,6 +136,29 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}-encryption-key"
       TargetKeyId: !Ref KMSEncryptionKey
 
+  PublishedKeysS3Bucket:
+    Type: AWS::S3::Bucket
+    # checkov:skip=CKV_AWS_18: "Ensure the S3 bucket has access logging enabled"
+    Properties:
+      BucketName: !Sub "${ServiceName}-${Environment}-key-rotation-bucket"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
+      NotificationConfiguration:
+        EventBridgeConfiguration:
+          EventBridgeEnabled: true
+      Tags:
+        - Key: "Description"
+          Value: "Published OAuth or DID keys bucket for key rotation state machine"
+
 Outputs:
   SigningKeyArn:
     Description: "The Arn of the VC signing key"
@@ -154,3 +186,13 @@ Outputs:
   EncryptionKeyAlias:
     Description: "The ARN of the encryption key"
     Value: !Ref KMSEncryptionKeyAlias
+  PublishedKeysS3BucketName:
+    Description: "The name of the bucket used by the key rotation state machine"
+    Value: !Ref PublishedKeysS3Bucket
+    Export:
+      Name: !Sub PublishedKeysS3BucketName
+  PublishedKeysS3BucketArn:
+    Description: "The ARN of the bucket used by the key rotation state machine"
+    Value: !GetAtt PublishedKeysS3Bucket.Arn
+    Export:
+      Name: !Sub PublishedKeysS3BucketArn


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

- Added new `ServiceName` parameter to be used in bucket naming
- Created `PublishedKeysS3Bucket` which will be used by the key rotation stack. This bucket stores the published keys and the key rotation stack publishes new keys to this bucket, and replaces/ removes old ones
- Linked PR for key rotation stack which is removing the bucket and importing the bucket from this api repo: https://github.com/govuk-one-login/identity-key-rotation/pull/67

### Why did it change

- Bucket needs to be created separately to the key rotation stack

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1516](https://govukverify.atlassian.net/browse/IPS-1516)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1516]: https://govukverify.atlassian.net/browse/IPS-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ