### PR TITLE
KIWI-2342: Removed custom groups and included only infra managed teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,4 @@
 # This is the CODEOWNERS file. These owners will be the default owners for everything in the ipv-cri-bav-api repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @govuk-one-login/kiwi-api-codeowners @govuk-one-login/kiwi-admins
-
-# The following allows QA to review changes to /tests directory
-
-tests/ @govuk-one-login/kiwi-qa-codeowners @govuk-one-login/kiwi-api-codeowners
+* @govuk-one-login/kiwi-admins @govuk-one-login/kiwi-devs


### PR DESCRIPTION
## Proposed changes

Removed manual created teams from CODEOWNERS

### Why did it change

To increase security and checks done on merging and to ensure teams are managed centrally
