### PR TITLE
KIWI-2443 - Switch Dynatrace Layers away from SecretsManager

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -305,9 +305,7 @@ Globals:
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
     Layers:
-      - !Sub
-        - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}' #pragma: allowlist secret # or PYTHON_LAYER or JAVA_LAYER
-        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_2_20250307-045250_with_collector_nodejs:1
     Timeout: 30 # seconds
     Tracing: Active
     MemorySize: 1024


### PR DESCRIPTION
## Proposed changes

Update hardcoded lambda Dynatrace layer to latest version ARN

### Issue tracking

- [KIWI-2443](https://govukverify.atlassian.net/browse/KIWI-2443)