### PR TITLE
[KIWI-2478] - BAV  | Add FMS tags for custom WAF policy migration in lower environments 

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -284,6 +284,10 @@ Conditions:
               - Fn::Equals:
                   - !Sub "${AWS::StackName}"
                   - "bav-cri-api"
+  IsDevOrBuildOrStaging: !Or
+    - !Equals [ !Ref Environment, dev ]
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
 
 Globals:
   Function:
@@ -686,8 +690,8 @@ Resources:
         Service: backend
         Name: BavRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [ IsDevOrBuildOrStaging, "false", "none" ]
+        CustomPolicy: !If [ IsDevOrBuildOrStaging, "true", "none" ]
 
   BAVAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed

Added regional API Gateway Tags to template file

### Why did it change

As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope.

### Issue tracking
- [KIWI-2478](https://govukverify.atlassian.net/browse/KIWI-2478)

<img width="1322" height="587" alt="Screenshot 2025-10-03 at 11 08 34" src="https://github.com/user-attachments/assets/8a53e20b-4ef8-479a-bba4-6df4681e1d76" />

