### PR TITLE
KIWI-2670 Node 22 to Node 24 uplift

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -112,7 +112,7 @@ jobs:
         id: ipv_stub_url
         run: |
           echo "ipv_stub_url=https://pre-merge-ipv-stub-${{ needs.setup.outputs.sha_short }}-ipvstub.review-bav.dev.account.gov.uk" >> $GITHUB_OUTPUT
-        
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -140,10 +140,10 @@ jobs:
           role-to-assume: ${{ secrets.DEV_CRI_BAV_PRE_MERGE_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: Setup nodeJS v22
+      - name: Setup nodeJS v24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       
       - name: Install dependencies
         working-directory: ./src

--- a/.github/workflows/pull-request-Dynamo.yml
+++ b/.github/workflows/pull-request-Dynamo.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v22
+      - name: Setup nodeJS v24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set offline mirror path
         id: offline-mirror-path

--- a/.github/workflows/pull-request-KMS.yml
+++ b/.github/workflows/pull-request-KMS.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v22
+      - name: Setup nodeJS v24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set offline mirror path
         id: offline-mirror-path

--- a/.github/workflows/pull-request-ipv-stub.yml
+++ b/.github/workflows/pull-request-ipv-stub.yml
@@ -36,10 +36,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v22
+      - name: Setup nodeJS v24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set offline mirror path
         id: offline-mirror-path

--- a/.github/workflows/pull-request-outboundproxy.yml
+++ b/.github/workflows/pull-request-outboundproxy.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v22
+      - name: Setup nodeJS v24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set offline mirror path
         id: offline-mirror-path

--- a/.github/workflows/pull-request-test-harness.yml
+++ b/.github/workflows/pull-request-test-harness.yml
@@ -36,10 +36,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v22
+      - name: Setup nodeJS v24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set offline mirror path
         id: offline-mirror-path

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -46,10 +46,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup nodeJS v22
+      - name: Setup nodeJS v24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set offline mirror path
         id: offline-mirror-path

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set offline mirror path
         id: offline-mirror-path

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -294,7 +298,7 @@
         "filename": "src/tests/unit/JwksHandler.test.ts",
         "hashed_secret": "e69cb67e72e1a1f4699b3de9d5085f820a0c7172",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 170
       }
     ],
     "src/tests/unit/PartialNameMatchHandler.test.ts": [
@@ -524,5 +528,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-08T14:28:13Z"
+  "generated_at": "2026-06-24T08:26:50Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt install -y curl unzip
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-ENV NODE_MAJOR=22
+ENV NODE_MAJOR=24
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update
 RUN apt-get install nodejs -y

--- a/bav-ipv-stub/src/JwtUtils.ts
+++ b/bav-ipv-stub/src/JwtUtils.ts
@@ -1,14 +1,15 @@
 import * as jose from "jose";
+import type { WithImplicitCoercion } from "node:buffer";
 
 export const jwtUtils = {
   // convert non-base64 string or uint8array into base64 encoded string
   base64Encode(value: string | WithImplicitCoercion<string>): string {
-    return jose.util.base64url.encode(Buffer.from(value), "utf8");
+    return jose.base64url.encode(new Uint8Array(Buffer.from(value)));
   },
 
   // convert base64 into uint8array
   base64DecodeToUint8Array(value: string): Uint8Array {
-    return new Uint8Array(jose.util.base64url.decode(value));
+    return jose.base64url.decode(value);
   },
 
   // convert base64 encoded string into non-base64 string

--- a/bav-ipv-stub/src/auth.types.ts
+++ b/bav-ipv-stub/src/auth.types.ts
@@ -29,7 +29,7 @@ export interface Jwks {
   keys: JsonWebKey[];
 }
 export interface JsonWebKey {
-  alg: "ES256" | "RS256";
+  alg: "ES256" | "RS256" | "RSA-OAEP-256";
   kid: string;
   kty: "EC" | "RSA";
   use: "sig" | "enc";

--- a/bav-ipv-stub/src/handlers/startBavCheck.ts
+++ b/bav-ipv-stub/src/handlers/startBavCheck.ts
@@ -146,9 +146,17 @@ async function getPublicEncryptionKey(config: {
     await axios.get(`${config.jwksUri}/.well-known/jwks.json`)
   ).data as Jwks;
   const publicKey = oauthProviderJwks.keys.find((key) => key.use === "enc");
+  if (publicKey == null) {
+    throw new Error("Missing encryption key in JWKS");
+  }
+
+  const publicRsaOaepKey = {
+    ...publicKey,
+    alg: "RSA-OAEP-256",
+  };
   const publicEncryptionKey: CryptoKey = await webcrypto.subtle.importKey(
     "jwk",
-    publicKey as JsonWebKey,
+    publicRsaOaepKey as JsonWebKey,
     { name: "RSA-OAEP", hash: "SHA-256" },
     true,
     ["encrypt"]

--- a/bav-ipv-stub/src/package-lock.json
+++ b/bav-ipv-stub/src/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/aws-lambda": "8.10.148",
         "@types/js-yaml": "4.0.9",
-        "@types/node": "20.14.8",
+        "@types/node": "24.0.0",
         "@types/uuid": "8.3.4",
         "@typescript-eslint/eslint-plugin": "8.56.1",
         "@typescript-eslint/parser": "8.56.1",
@@ -33,7 +33,7 @@
         "yaml-cfn": "0.3.2"
       },
       "engines": {
-        "node": "22.*"
+        "node": "24.*"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -2084,13 +2084,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/sinon": {
@@ -4712,9 +4712,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },

--- a/bav-ipv-stub/src/package.json
+++ b/bav-ipv-stub/src/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/aws-lambda": "8.10.148",
     "@types/js-yaml": "4.0.9",
-    "@types/node": "20.14.8",
+    "@types/node": "24.0.0",
     "@types/uuid": "8.3.4",
     "@typescript-eslint/eslint-plugin": "8.56.1",
     "@typescript-eslint/parser": "8.56.1",
@@ -35,7 +35,7 @@
     "compile": "./node_modules/.bin/tsc"
   },
   "engines": {
-    "node": "22.*"
+    "node": "24.*"
   },
   "type": "module"
 }

--- a/bav-ipv-stub/src/tests/startBavCheck.test.ts
+++ b/bav-ipv-stub/src/tests/startBavCheck.test.ts
@@ -24,7 +24,7 @@ const mockJwks = {
       e: "AQAB",
       use: "enc",
       kid: "569c43c6-8136-42c9-932d-fbcdddbfd778",
-      alg: "RSA-OAEP-256",
+      alg: "RS256",
     },
   ],
 };

--- a/bav-ipv-stub/template.yaml
+++ b/bav-ipv-stub/template.yaml
@@ -86,7 +86,7 @@ Globals:
   Function:
     Tracing: Active
     MemorySize: 512
-    Runtime: nodejs20.x
+    Runtime: nodejs24.x
     Timeout: 60
     Tags:
       API: !Sub ${AWS::StackName}-test-resource

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -287,7 +287,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs24.x
     VpcConfig:
       SecurityGroupIds:
         - !GetAtt LambdaEgressSecurityGroup.GroupId

--- a/infra-l2-dynamo/src/package-lock.json
+++ b/infra-l2-dynamo/src/package-lock.json
@@ -13,7 +13,7 @@
             "devDependencies": {
                 "@types/aws-lambda": "8.10.148",
                 "@types/js-yaml": "4.0.9",
-                "@types/node": "20.14.8",
+                "@types/node": "24.0.0",
                 "aws-cdk-lib": "2.257.0",
                 "js-yaml": "4.1.1",
                 "typescript": "4.9.4",
@@ -882,13 +882,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.14.8",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-            "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+            "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~7.8.0"
             }
         },
         "node_modules/@vitest/expect": {
@@ -2052,9 +2052,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
             "dev": true,
             "license": "MIT"
         },

--- a/infra-l2-dynamo/src/package.json
+++ b/infra-l2-dynamo/src/package.json
@@ -8,7 +8,7 @@
     },
     "devDependencies": {
         "@types/aws-lambda": "8.10.148",
-        "@types/node": "20.14.8",
+        "@types/node": "24.0.0",
         "aws-cdk-lib": "2.257.0",
         "@types/js-yaml": "4.0.9",
         "js-yaml": "4.1.1",

--- a/infra-l2-kms/src/package-lock.json
+++ b/infra-l2-kms/src/package-lock.json
@@ -13,7 +13,7 @@
             "devDependencies": {
                 "@types/aws-lambda": "8.10.148",
                 "@types/js-yaml": "4.0.9",
-                "@types/node": "20.14.8",
+                "@types/node": "24.0.0",
                 "aws-cdk-lib": "2.257.0",
                 "js-yaml": "4.1.1",
                 "typescript": "4.9.4",
@@ -882,13 +882,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.14.8",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-            "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+            "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~7.8.0"
             }
         },
         "node_modules/@vitest/expect": {
@@ -2052,9 +2052,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
             "dev": true,
             "license": "MIT"
         },

--- a/infra-l2-kms/src/package.json
+++ b/infra-l2-kms/src/package.json
@@ -8,7 +8,7 @@
     },
     "devDependencies": {
         "@types/aws-lambda": "8.10.148",
-        "@types/node": "20.14.8",
+        "@types/node": "24.0.0",
         "aws-cdk-lib": "2.257.0",
         "@types/js-yaml": "4.0.9",
         "js-yaml": "4.1.1",

--- a/infra-l2-outbound-proxy/src/package-lock.json
+++ b/infra-l2-outbound-proxy/src/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@types/aws-lambda": "8.10.148",
         "@types/js-yaml": "4.0.9",
-        "@types/node": "20.14.8",
+        "@types/node": "24.0.0",
         "aws-cdk-lib": "2.257.0",
         "js-yaml": "4.1.1",
         "typescript": "4.9.4",
@@ -882,13 +882,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2052,9 +2052,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },

--- a/infra-l2-outbound-proxy/src/package.json
+++ b/infra-l2-outbound-proxy/src/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.148",
-    "@types/node": "20.14.8",
+    "@types/node": "24.0.0",
     "aws-cdk-lib": "2.257.0",
     "@types/js-yaml": "4.0.9",
     "js-yaml": "4.1.1",

--- a/src/AbortHandler.ts
+++ b/src/AbortHandler.ts
@@ -1,5 +1,6 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { AbortRequestProcessor } from "./services/AbortRequestProcessor";
@@ -13,7 +14,7 @@ import { getSessionIdHeaderErrors } from "./utils/Validations";
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.ABORT_LOGGER_SVC_NAME } = process.env;
 
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 

--- a/src/AccessTokenHandler.ts
+++ b/src/AccessTokenHandler.ts
@@ -1,7 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { Constants } from "./utils/Constants";
 import { Response } from "./utils/Response";
 import { MessageCodes } from "./models/enums/MessageCodes";
@@ -12,7 +13,7 @@ import { AppError } from "./utils/AppError";
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.ACCESSTOKEN_LOGGER_SVC_NAME } = process.env;
 
 const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 

--- a/src/AuthorizationHandler.ts
+++ b/src/AuthorizationHandler.ts
@@ -1,5 +1,6 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { HttpCodesEnum } from "./models/enums/HttpCodesEnum";
@@ -12,7 +13,7 @@ import { Constants } from "./utils/Constants";
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.AUTHORIZATION_LOGGER_SVC_NAME } = process.env;
 
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 

--- a/src/DeleteBucketHandler.ts
+++ b/src/DeleteBucketHandler.ts
@@ -1,4 +1,4 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { HttpCodesEnum } from "./utils/HttpCodesEnum";
 import { DeleteBucketProcessor } from "./services/DeleteBucketProcessor";
 import { Response } from "./utils/Response";

--- a/src/HmrcTokenHandler.ts
+++ b/src/HmrcTokenHandler.ts
@@ -1,5 +1,6 @@
 import { Logger } from "@aws-lambda-powertools/logger";
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Constants, EnvironmentVariables } from "./utils/Constants";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { MessageCodes } from "./models/enums/MessageCodes";
@@ -11,7 +12,7 @@ import { HttpCodesEnum } from "./models/enums/HttpCodesEnum";
 
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.HMRC_TOKEN_LOGGER_SVC_NAME } = process.env;
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 export const metrics = new Metrics({ namespace: POWERTOOLS_METRICS_NAMESPACE, serviceName: POWERTOOLS_SERVICE_NAME });

--- a/src/JwksHandler.ts
+++ b/src/JwksHandler.ts
@@ -1,5 +1,6 @@
 import { Logger } from "@aws-lambda-powertools/logger";
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Constants, EnvironmentVariables } from "./utils/Constants";
 import { Jwk, JWKSBody, Algorithm } from "./models/IVeriCredential";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
@@ -11,7 +12,7 @@ import { checkEnvironmentVariable } from "./utils/EnvironmentVariables";
 const POWERTOOLS_LOG_LEVEL = process.env.POWERTOOLS_LOG_LEVEL ? process.env.POWERTOOLS_LOG_LEVEL : "DEBUG";
 const POWERTOOLS_SERVICE_NAME = process.env.POWERTOOLS_SERVICE_NAME ? process.env.POWERTOOLS_SERVICE_NAME : Constants.JWKS_LOGGER_SVC_NAME;
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 
@@ -78,11 +79,12 @@ class JwksHandler implements LambdaInterface {
 		const map = this.getKeySpecMap(kmsKey?.KeySpec);
 		if (
 			kmsKey != null &&
-					map != null &&
-					kmsKey.KeyId != null &&
-					kmsKey.PublicKey != null
+			map != null &&
+			kmsKey.KeyId != null &&
+			kmsKey.PublicKey != null
 		) {
 			const use = kmsKey.KeyUsage === "ENCRYPT_DECRYPT" ? "enc" : "sig";
+			const alg = use === "enc" ? "RSA-OAEP-256" : map.algorithm;
 			const publicKey = crypto
 				.createPublicKey({
 					key: kmsKey.PublicKey as Buffer,
@@ -94,7 +96,7 @@ class JwksHandler implements LambdaInterface {
 				...publicKey,
 				use,
 				kid: keyId.split("/").pop(),
-				alg: map.algorithm,
+				alg,
 			} as unknown as Jwk;
 		}
 		logger.error({ message: "Failed to build JWK from key" + keyId }, JSON.stringify(map));

--- a/src/PartialNameMatchHandler.ts
+++ b/src/PartialNameMatchHandler.ts
@@ -1,7 +1,8 @@
 import { Context, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Constants, EnvironmentVariables } from "./utils/Constants";
 import { failEntireBatch, passEntireBatch } from "./utils/SqsBatchResponseHelper";
 import { PutObjectCommand, S3Client, ServerSideEncryption } from "@aws-sdk/client-s3";
@@ -12,7 +13,7 @@ import { absoluteTimeNow } from "./utils/DateTimeUtils";
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.PARTIAL_NAME_MATCH_HANDLER } = process.env;
 
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 
@@ -87,4 +88,3 @@ class PartialNameMatchHandler implements LambdaInterface {
 
 const handlerClass = new PartialNameMatchHandler();
 export const lambdaHandler = handlerClass.handler.bind(handlerClass);
-

--- a/src/PersonInfoHandler.ts
+++ b/src/PersonInfoHandler.ts
@@ -1,5 +1,6 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { PersonInfoRequestProcessor } from "./services/PersonInfoRequestProcessor";
@@ -15,7 +16,7 @@ import { getSessionIdHeaderErrors } from "./utils/Validations";
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.ABORT_LOGGER_SVC_NAME } = process.env;
 
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 

--- a/src/PersonInfoKeyHandler.ts
+++ b/src/PersonInfoKeyHandler.ts
@@ -1,5 +1,6 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { HttpCodesEnum } from "./models/enums/HttpCodesEnum";
@@ -12,7 +13,7 @@ import { Response } from "./utils/Response";
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.PERSON_INFO_KEY_LOGGER_SVC_NAME } = process.env;
 
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 

--- a/src/SessionHandler.ts
+++ b/src/SessionHandler.ts
@@ -1,5 +1,6 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { SessionRequestProcessor } from "./services/SessionRequestProcessor";
@@ -11,7 +12,7 @@ import { Constants } from "./utils/Constants";
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.SESSION_LOGGER_SVC_NAME } = process.env;
 
 const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 

--- a/src/UserInfoHandler.ts
+++ b/src/UserInfoHandler.ts
@@ -1,5 +1,6 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { UserInfoRequestProcessor } from "./services/UserInfoRequestProcessor";
@@ -13,7 +14,7 @@ import { checkEnvironmentVariable } from "./utils/EnvironmentVariables";
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.USERINFO_LOGGER_SVC_NAME } = process.env;
 
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 

--- a/src/VerifyAccountHandler.ts
+++ b/src/VerifyAccountHandler.ts
@@ -1,7 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 import { MessageCodes } from "./models/enums/MessageCodes";
 import { HttpCodesEnum } from "./models/enums/HttpCodesEnum";
 import { VerifyAccountRequestProcessor } from "./services/VerifyAccountRequestProcessor";
@@ -17,7 +18,7 @@ import { getPayloadValidationErrors } from "./utils/VerifyAccountRequestValidati
 const { POWERTOOLS_METRICS_NAMESPACE = Constants.BAV_METRICS_NAMESPACE, POWERTOOLS_LOG_LEVEL = "DEBUG", POWERTOOLS_SERVICE_NAME = Constants.ACCESSTOKEN_LOGGER_SVC_NAME } = process.env;
 
 export const logger = new Logger({
-	logLevel: POWERTOOLS_LOG_LEVEL,
+	logLevel: POWERTOOLS_LOG_LEVEL as LogLevel,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 

--- a/src/models/IVeriCredential.ts
+++ b/src/models/IVeriCredential.ts
@@ -13,6 +13,7 @@ export type Algorithm =
 	"RS256" | "RS384" | "RS512" |
 	"ES256" | "ES384" | "ES512" |
 	"PS256" | "PS384" | "PS512" |
+	"RSA-OAEP-256" |
 	"none";
 	
 export interface CredentialJwt {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "1.5.1",
-        "@aws-lambda-powertools/logger": "1.5.1",
-        "@aws-lambda-powertools/metrics": "1.5.1",
+        "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws-lambda-powertools/logger": "2.33.1",
+        "@aws-lambda-powertools/metrics": "2.33.1",
         "@aws-sdk/client-cloudwatch": "3.1045.0",
         "@aws-sdk/client-dynamodb": "3.1045.0",
         "@aws-sdk/client-kms": "3.1045.0",
@@ -38,7 +38,7 @@
         "@types/express": "4.17.21",
         "@types/js-yaml": "4.0.9",
         "@types/jsonpath": "0.2.4",
-        "@types/node": "20.14.8",
+        "@types/node": "24.0.0",
         "@types/node-rsa": "1.1.4",
         "@typescript-eslint/eslint-plugin": "8.56.1",
         "@typescript-eslint/parser": "8.56.1",
@@ -63,7 +63,7 @@
         "yaml-cfn": "0.3.2"
       },
       "engines": {
-        "node": "22.*"
+        "node": "24.*"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -247,31 +247,52 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.5.1.tgz",
-      "integrity": "sha512-qp13/WksB6M/liEHgV3301qmI/aeQKmrYk1iODB+rrkVWeKW4AJqBMuWQ26gIlbD8t82EtuUNPUFle1a2qwjIg==",
-      "deprecated": "Version 1.x has reached End-of-Life, please upgrade to 2.x, more info here: https://s12d.com/upgrade-v2",
-      "license": "MIT-0"
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.33.1.tgz",
+      "integrity": "sha512-edzvz+zqBl8p9J2Cgo1rFmhd+3ANqr0PQDqowElS3CJ10ioHN2wUYiANGxfalcgbB8ulZxGkRbK3wvEEziV/5w==",
+      "license": "MIT-0",
+      "dependencies": {
+        "@aws/lambda-invoke-store": "0.2.4"
+      }
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.5.1.tgz",
-      "integrity": "sha512-dXvw7c4Z0DUEY62zEWsQ4DQZ3yf+JsEAqojQH+kw+rXVv0cjnIEbM4ZKONPG2jcPS5IMzO6gmCbu/PKB1PYgyA==",
-      "deprecated": "Version 1.x has reached End-of-Life, please upgrade to 2.x, more info here: https://s12d.com/upgrade-v2",
-      "license": "MIT",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.33.1.tgz",
+      "integrity": "sha512-DDnKcv2zghslh2AtrVsa4wHcAuI5M7+JlX65CgdXLk2th0Nr0octJQq0f4Bnp+DzuwFynmH4GJqsBe33rZapAw==",
+      "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.5.1",
-        "lodash.merge": "^4.6.2"
+        "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws/lambda-invoke-store": "0.2.4"
+      },
+      "peerDependencies": {
+        "@aws-lambda-powertools/jmespath": "2.33.1",
+        "@middy/core": "4.x || 5.x || 6.x || 7.x"
+      },
+      "peerDependenciesMeta": {
+        "@aws-lambda-powertools/jmespath": {
+          "optional": true
+        },
+        "@middy/core": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-1.5.1.tgz",
-      "integrity": "sha512-kBvJR9phGdH5UqtcWyxVMQoZU57liQeVxZCFbDMSAhdlxBbW1pkPBASaKv/FLlX++Tb4TeO1Tj28dox1yL1t+w==",
-      "deprecated": "Version 1.x has reached End-of-Life, please upgrade to 2.x, more info here: https://s12d.com/upgrade-v2",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-2.33.1.tgz",
+      "integrity": "sha512-QtkymyPtLqMuxTcwfHLahw2UOcHeEGISL3kA+5/mdBiHjnQE0qeWZKZ+SzMOwMTWvD2jHYN+K5F/8SODDb6yIQ==",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.5.1"
+        "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws/lambda-invoke-store": "0.2.4"
+      },
+      "peerDependencies": {
+        "@middy/core": "4.x || 5.x || 6.x || 7.x"
+      },
+      "peerDependenciesMeta": {
+        "@middy/core": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/checksums": {
@@ -3462,12 +3483,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/node-rsa": {
@@ -6996,12 +7017,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.omit": {
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
@@ -9111,9 +9126,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
     },
     "node_modules/unixify": {

--- a/src/package.json
+++ b/src/package.json
@@ -6,9 +6,9 @@
   "author": "GDS",
   "license": "MIT",
   "dependencies": {
-    "@aws-lambda-powertools/commons": "1.5.1",
-    "@aws-lambda-powertools/logger": "1.5.1",
-    "@aws-lambda-powertools/metrics": "1.5.1",
+    "@aws-lambda-powertools/commons": "2.33.1",
+    "@aws-lambda-powertools/logger": "2.33.1",
+    "@aws-lambda-powertools/metrics": "2.33.1",
     "@aws-sdk/client-cloudwatch": "3.1045.0",
     "@aws-sdk/client-dynamodb": "3.1045.0",
     "@aws-sdk/client-kms": "3.1045.0",
@@ -52,7 +52,7 @@
     "@types/aws-lambda": "8.10.148",
     "@types/express": "4.17.21",
     "@types/js-yaml": "4.0.9",
-    "@types/node": "20.14.8",
+    "@types/node": "24.0.0",
     "@types/node-rsa": "1.1.4",
     "@typescript-eslint/eslint-plugin": "8.56.1",
     "@typescript-eslint/parser": "8.56.1",
@@ -79,7 +79,7 @@
     "vitest-mock-extended": "4.0.0"
   },
   "engines": {
-   "node": "22.*"
+   "node": "24.*"
   },
   "type": "module"
 }

--- a/src/services/AccessTokenRequestProcessor.ts
+++ b/src/services/AccessTokenRequestProcessor.ts
@@ -1,5 +1,5 @@
 import { Logger } from "@aws-lambda-powertools/logger";
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
 import { BavService } from "./BavService";
 import { KmsJwtAdapter } from "../utils/KmsJwtAdapter";
 import { HttpCodesEnum } from "../utils/HttpCodesEnum";
@@ -171,7 +171,7 @@ export class AccessTokenRequestProcessor {
 					}),
 				};
 			} else {
-				this.metrics.addMetric("AccessToken_error_user_state_incorrect", MetricUnits.Count, 1);
+				this.metrics.addMetric("AccessToken_error_user_state_incorrect", MetricUnit.Count, 1);
 				this.logger.warn(`Session for journey ${session?.clientSessionId} is in the wrong Auth state: expected state - ${AuthSessionState.BAV_AUTH_CODE_ISSUED}, actual state - ${session.authSessionState}`, { messageCode: MessageCodes.INCORRECT_SESSION_STATE });
 				return Response(HttpCodesEnum.UNAUTHORIZED, `Session for journey ${session?.clientSessionId} is in the wrong Auth state: expected state - ${AuthSessionState.BAV_AUTH_CODE_ISSUED}, actual state - ${session.authSessionState}`);
 			}

--- a/src/services/AuthorizationRequestProcessor.ts
+++ b/src/services/AuthorizationRequestProcessor.ts
@@ -1,4 +1,4 @@
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { randomUUID } from "crypto";
 import { BavService } from "./BavService";
@@ -47,7 +47,7 @@ export class AuthorizationRequestProcessor {
 		}
 
 		this.logger.appendKeys({ govuk_signin_journey_id: session.clientSessionId });
-		this.metrics.addMetric("found session", MetricUnits.Count, 1);
+		this.metrics.addMetric("found session", MetricUnit.Count, 1);
 
 		switch (session.authSessionState) {
 			case AuthSessionState.BAV_DATA_RECEIVED:
@@ -64,7 +64,7 @@ export class AuthorizationRequestProcessor {
 
 		const authorizationCode = randomUUID();
 		await this.BavService.setAuthorizationCode(sessionId, authorizationCode);
-		this.metrics.addMetric("Set authorization code", MetricUnits.Count, 1);
+		this.metrics.addMetric("Set authorization code", MetricUnit.Count, 1);
 
 		const authResponse = {
 			authorizationCode: {

--- a/src/services/ExperianService.ts
+++ b/src/services/ExperianService.ts
@@ -9,7 +9,7 @@ import { DynamoDBDocument, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb"
 import { randomUUID } from "crypto";
 import { logResponseCode } from "../utils/LogResponseCode";
 import { checkEnvironmentVariable } from "../utils/EnvironmentVariables";
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
 import { ExperianVerifyResponse } from "../models/IVeriCredential";
 
 export class ExperianService {
@@ -133,7 +133,7 @@ export class ExperianService {
     		const expRequestId = responseHeader?.expRequestId;
 
     		const decision = responseHeader?.overallResponse?.decision;
-    		this.metrics.addMetric("Experian-" + decision, MetricUnits.Count, 1);
+				this.metrics.addMetric("Experian-" + decision, MetricUnit.Count, 1);
 
     		let warningsErrors = undefined;
     		let personalDetailsScore = undefined;
@@ -159,7 +159,7 @@ export class ExperianService {
     			if (scores) {
     				personalDetailsScore = scores.find((object: { name: string; score: number }) => object.name === "Personal details")?.score;
     				this.logger.info("Personal details score is " + personalDetailsScore);
-    				this.metrics.addMetric("PersonalDetailsScore-" + personalDetailsScore, MetricUnits.Count, 1);
+						this.metrics.addMetric("PersonalDetailsScore-" + personalDetailsScore, MetricUnit.Count, 1);
     			} else {
     				this.logger.warn("No scores present in response");
     			}
@@ -206,7 +206,7 @@ export class ExperianService {
     		eventOutcome,
     	});
     	if (eventOutcome) {
-    		this.metrics.addMetric("Experian-" + eventOutcome.replace(" ", "_"), MetricUnits.Count, 1);
+			this.metrics.addMetric("Experian-" + eventOutcome.replace(" ", "_"), MetricUnit.Count, 1);
     	}
     }
 
@@ -329,4 +329,3 @@ export class ExperianService {
     	} 
     }
 }
-

--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -1,7 +1,7 @@
  
  
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { BavService } from "./BavService";
 import { AuthSessionState } from "../models/enums/AuthSessionState";
@@ -51,7 +51,7 @@ export class SessionRequestProcessor {
   	this.logger = logger;
   	this.metrics = metrics;
   	logger.debug("metrics is  " + JSON.stringify(this.metrics));
-  	this.metrics.addMetric("Called", MetricUnits.Count, 1);
+		this.metrics.addMetric("Called", MetricUnit.Count, 1);
 
   	const sessionTableName: string = checkEnvironmentVariable(EnvironmentVariables.SESSION_TABLE, this.logger);
   	const encryptionKeyIds: string = checkEnvironmentVariable(EnvironmentVariables.ENCRYPTION_KEY_IDS, this.logger);

--- a/src/services/UserInfoRequestProcessor.ts
+++ b/src/services/UserInfoRequestProcessor.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { BavService } from "./BavService";
 import { AuthSessionState } from "../models/enums/AuthSessionState";
@@ -46,7 +46,7 @@ export class UserInfoRequestProcessor {
   	this.logger = logger;
   	this.metrics = metrics;
   	logger.debug("metrics is  " + JSON.stringify(this.metrics));
-  	this.metrics.addMetric("Called", MetricUnits.Count, 1);
+		this.metrics.addMetric("Called", MetricUnit.Count, 1);
 
   	const sessionTableName: string = checkEnvironmentVariable(EnvironmentVariables.SESSION_TABLE, this.logger);
   	const signinKeyIds: string = checkEnvironmentVariable(EnvironmentVariables.KMS_KEY_ARN, this.logger);
@@ -113,7 +113,7 @@ export class UserInfoRequestProcessor {
 			},
 		});
   
-		this.metrics.addMetric("found session data", MetricUnits.Count, 1);
+		this.metrics.addMetric("found session data", MetricUnit.Count, 1);
 
 		const personInfo = await this.BavService.getPersonIdentityBySessionId(sessionId, this.personIdentityTableName);
 		if (!personInfo) {
@@ -123,7 +123,7 @@ export class UserInfoRequestProcessor {
 			return Response(HttpCodesEnum.UNAUTHORIZED, "Missing Person Identity");
 		}
 
-		this.metrics.addMetric("found person identity data", MetricUnits.Count, 1);
+		this.metrics.addMetric("found person identity data", MetricUnit.Count, 1);
 
 		if (session.authSessionState !== AuthSessionState.BAV_ACCESS_TOKEN_ISSUED) {
 			this.logger.error("Session is in wrong Auth state", {
@@ -151,7 +151,7 @@ export class UserInfoRequestProcessor {
 				},
 				absoluteTimeNow);
 
-			this.metrics.addMetric("Generated signed verifiable credential jwt", MetricUnits.Count, 1);
+			this.metrics.addMetric("Generated signed verifiable credential jwt", MetricUnit.Count, 1);
 
 			await this.BavService.updateSessionAuthState(session.sessionId, AuthSessionState.BAV_CRI_VC_ISSUED);
 			await this.sendTXMAEvents(session, evidenceInfo, personInfo);

--- a/src/services/VerifyAccountRequestProcessor.ts
+++ b/src/services/VerifyAccountRequestProcessor.ts
@@ -1,5 +1,5 @@
  
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { randomUUID } from "crypto";
 import { BavService } from "./BavService";
@@ -56,7 +56,7 @@ export class VerifyAccountRequestProcessor {
   	this.metrics = metrics;
   	this.credentialVendor = CREDENTIAL_VENDOR;
   	logger.debug("metrics is  " + JSON.stringify(this.metrics));
-  	this.metrics.addMetric("Called", MetricUnits.Count, 1);
+		this.metrics.addMetric("Called", MetricUnit.Count, 1);
 
   	this.txmaQueueUrl = checkEnvironmentVariable(EnvironmentVariables.TXMA_QUEUE_URL, this.logger);
   	this.issuer = checkEnvironmentVariable(EnvironmentVariables.ISSUER, this.logger);
@@ -211,7 +211,7 @@ export class VerifyAccountRequestProcessor {
   		} else {
   			attemptCount = 1;
   		}
-  		this.metrics.addMetric("retry-attempt-" + attemptCount, MetricUnits.Count, 1);
+			this.metrics.addMetric("retry-attempt-" + attemptCount, MetricUnit.Count, 1);
 		  }
 
 		  await this.BavService.saveExperianCheckResult(sessionId, verifyResponse, experianCheckResult, attemptCount, cis);
@@ -224,7 +224,7 @@ export class VerifyAccountRequestProcessor {
   private logCis(cis: string[] | undefined, metrics: Metrics): void {
   	if (cis) {
   		cis.forEach(function (ci): void {
-  			metrics.addMetric("ci-" + ci, MetricUnits.Count, 1);
+				metrics.addMetric("ci-" + ci, MetricUnit.Count, 1);
   		});
   	}
   }
@@ -411,15 +411,15 @@ export class VerifyAccountRequestProcessor {
 	  warningError.forEach(function (value): void {
 		  if (value?.responseType === "warning") {
 			  if (criticalWarnings.includes(value.responseCode)) {
-				  metrics.addMetric("critical-experian-response-code" + value.responseCode, MetricUnits.Count, 1);
+				  metrics.addMetric("critical-experian-response-code" + value.responseCode, MetricUnit.Count, 1);
 				  isCriticalResponse = true;
 			  }
 		  }
 		  if (value?.responseType === "error") {
 			  if (criticalErrors.includes(value.responseCode)) {
-  					metrics.addMetric("critical-experian-response-code" + value.responseCode, MetricUnits.Count, 1);
-  					isCriticalResponse = true;
-  				}
+						metrics.addMetric("critical-experian-response-code" + value.responseCode, MetricUnit.Count, 1);
+						isCriticalResponse = true;
+					}
 		  }
 		  if (value.responseType === undefined || value.responseType === "") {
   				logger.info("Captured empty response type in warning and errors array ");

--- a/src/tests/unit/JwksHandler.test.ts
+++ b/src/tests/unit/JwksHandler.test.ts
@@ -93,6 +93,32 @@ describe("JwksHandler", () => {
 			vi.spyOn(handlerClass.kmsClient, "getPublicKey").mockImplementationOnce(() => ({
 				KeySpec: "ECC_NIST_P256",
 				KeyId: keyId,
+				KeyUsage: "SIGN_VERIFY",
+				PublicKey: publicKey,
+			}));
+
+			const result = await handlerClass.getAsJwk(keyId);
+
+			expect(handlerClass.kmsClient.getPublicKey).toHaveBeenCalledWith({ KeyId: keyId });
+			expect(crypto.createPublicKey).toHaveBeenCalledWith({
+				key: publicKey as unknown as Buffer,
+				type: "spki",
+				format: "der",
+			});
+			expect(result).toEqual({
+				key: "123456789",
+				use: "sig",
+				kid: keyId.split("/").pop(),
+				alg: "ES256" as Algorithm,
+			} as unknown as Jwk);
+		});
+
+		it("returns RSA encryption jwk with RSA-OAEP-256 alg", async () => {
+			const keyId = "bav-cri-api-encryption-key";
+			const publicKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQE";
+			vi.spyOn(handlerClass.kmsClient, "getPublicKey").mockImplementationOnce(() => ({
+				KeySpec: "RSA_2048",
+				KeyId: keyId,
 				KeyUsage: "ENCRYPT_DECRYPT",
 				PublicKey: publicKey,
 			}));
@@ -109,7 +135,7 @@ describe("JwksHandler", () => {
 				key: "123456789",
 				use: "enc",
 				kid: keyId.split("/").pop(),
-				alg: "ES256" as Algorithm,
+				alg: "RSA-OAEP-256" as Algorithm,
 			} as unknown as Jwk);
 		});
 

--- a/src/tests/unit/services/AccessTokenRequestProcessor.test.ts
+++ b/src/tests/unit/services/AccessTokenRequestProcessor.test.ts
@@ -1,6 +1,6 @@
  
 import { Metrics } from "@aws-lambda-powertools/metrics";
-import { MetricUnits } from "@aws-lambda-powertools/metrics";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
 import { mock } from "vitest-mock-extended";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { BavService } from "../../../services/BavService";
@@ -163,7 +163,7 @@ describe("AccessTokenRequestProcessor", () => {
 	 	expect(logger.warn).toHaveBeenCalledWith(
 	 				"Session for journey sdfssg is in the wrong Auth state: expected state - BAV_AUTH_CODE_ISSUED, actual state - BAV_ACCESS_TOKEN_ISSUED", { messageCode: MessageCodes.INCORRECT_SESSION_STATE },
 	 	);
-	 	expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "AccessToken_error_user_state_incorrect", MetricUnits.Count, 1);	
+		 expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "AccessToken_error_user_state_incorrect", MetricUnit.Count, 1);
 
 	 	expect(out.body).toBe("Session for journey sdfssg is in the wrong Auth state: expected state - BAV_AUTH_CODE_ISSUED, actual state - BAV_ACCESS_TOKEN_ISSUED");
 	 	expect(out.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);

--- a/src/utils/JwtUtils.ts
+++ b/src/utils/JwtUtils.ts
@@ -1,5 +1,6 @@
 import * as jose from "jose";
 import crypto from "crypto";
+import type { WithImplicitCoercion } from "node:buffer";
 
 export const jwtUtils = {
 

--- a/src/utils/KmsJwtAdapter.ts
+++ b/src/utils/KmsJwtAdapter.ts
@@ -1,5 +1,5 @@
 import format from "ecdsa-sig-formatter";
-import { Buffer } from "buffer";
+import { Buffer } from "node:buffer";
 import { Jwt, JwtHeader, JwtPayload, JsonWebTokenError, Jwk } from "../models/IVeriCredential";
 import { jwtUtils } from "./JwtUtils";
 import { DecryptCommand, DecryptCommandInput, DecryptCommandOutput, KMS, MessageType, SigningAlgorithmSpec } from "@aws-sdk/client-kms";

--- a/src/utils/LogResponseCode.ts
+++ b/src/utils/LogResponseCode.ts
@@ -1,4 +1,4 @@
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
 
 export const logResponseCode = (warningsErrors: Array<{ responseType: string; responseCode: string; responseMessage: string }>, logger: any, metrics: Metrics): any => {
 
@@ -8,6 +8,6 @@ export const logResponseCode = (warningsErrors: Array<{ responseType: string; re
 			logger.info(`Response code: ${warningError?.responseCode}, Response message: ${warningError?.responseMessage}`);
 			responseCodeMetric.addDimension("experian-response-code", warningError?.responseCode);
 		});
-		responseCodeMetric.addMetric("ResponseCodes", MetricUnits.Count, 1); 
+		responseCodeMetric.addMetric("ResponseCodes", MetricUnit.Count, 1);
 	}
 };

--- a/test-harness/src/AthenaQueryHandler.ts
+++ b/test-harness/src/AthenaQueryHandler.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { Constants } from "./utils/Constants";
@@ -16,7 +16,7 @@ import {
 } from "@aws-sdk/client-athena";
 import { setTimeout } from "timers/promises";
 import { convertAthenaResultsToListOfRecords } from "./utils/ConvertAthenaResultToListOfRecords";
-import { LogLevel } from "@aws-lambda-powertools/logger/lib/types";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 
 const POWERTOOLS_METRICS_NAMESPACE =
   process.env.POWERTOOLS_METRICS_NAMESPACE ?? Constants.BAV_METRICS_NAMESPACE;

--- a/test-harness/src/DequeueHandler.ts
+++ b/test-harness/src/DequeueHandler.ts
@@ -1,11 +1,11 @@
 import { SQSEvent } from "aws-lambda";
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { Constants } from "./utils/Constants";
 import { BatchItemFailure } from "./utils/BatchItemFailure";
-import { LogLevel } from "@aws-lambda-powertools/logger/lib/types";
+import { LogLevel } from "@aws-lambda-powertools/logger/types";
 
 const POWERTOOLS_LOG_LEVEL = process.env.POWERTOOLS_LOG_LEVEL
 	? process.env.POWERTOOLS_LOG_LEVEL

--- a/test-harness/src/package-lock.json
+++ b/test-harness/src/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-lambda-powertools/logger": "1.5.1",
-        "@aws-lambda-powertools/metrics": "1.5.1",
+        "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws-lambda-powertools/logger": "2.33.1",
+        "@aws-lambda-powertools/metrics": "2.33.1",
         "@aws-sdk/client-athena": "3.1045.0",
         "@aws-sdk/client-s3": "3.1045.0",
         "@smithy/node-http-handler": "4.0.4",
@@ -19,7 +20,7 @@
       "devDependencies": {
         "@babel/preset-typescript": "7.22.5",
         "@types/aws-lambda": "8.10.148",
-        "@types/node": "20.14.8",
+        "@types/node": "24.0.0",
         "@typescript-eslint/eslint-plugin": "8.56.1",
         "@typescript-eslint/parser": "8.56.1",
         "@vitest/coverage-v8": "4.1.4",
@@ -30,7 +31,7 @@
         "vitest": "4.1.4"
       },
       "engines": {
-        "node": "22.*"
+        "node": "24.*"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -161,31 +162,52 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.18.1.tgz",
-      "integrity": "sha512-gFRgQ2GJDghKvf+fXvT0kQVftgOT05W+hCa7RkfZj6HSjVAO+9DZZeJL3JK1HcsLAjWRj7W9ra0/MqB3Abf+PQ==",
-      "deprecated": "Version 1.x has reached End-of-Life, please upgrade to 2.x, more info here: https://s12d.com/upgrade-v2",
-      "license": "MIT-0"
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.33.1.tgz",
+      "integrity": "sha512-edzvz+zqBl8p9J2Cgo1rFmhd+3ANqr0PQDqowElS3CJ10ioHN2wUYiANGxfalcgbB8ulZxGkRbK3wvEEziV/5w==",
+      "license": "MIT-0",
+      "dependencies": {
+        "@aws/lambda-invoke-store": "0.2.4"
+      }
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.5.1.tgz",
-      "integrity": "sha512-dXvw7c4Z0DUEY62zEWsQ4DQZ3yf+JsEAqojQH+kw+rXVv0cjnIEbM4ZKONPG2jcPS5IMzO6gmCbu/PKB1PYgyA==",
-      "deprecated": "Version 1.x has reached End-of-Life, please upgrade to 2.x, more info here: https://s12d.com/upgrade-v2",
-      "license": "MIT",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.33.1.tgz",
+      "integrity": "sha512-DDnKcv2zghslh2AtrVsa4wHcAuI5M7+JlX65CgdXLk2th0Nr0octJQq0f4Bnp+DzuwFynmH4GJqsBe33rZapAw==",
+      "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.5.1",
-        "lodash.merge": "^4.6.2"
+        "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws/lambda-invoke-store": "0.2.4"
+      },
+      "peerDependencies": {
+        "@aws-lambda-powertools/jmespath": "2.33.1",
+        "@middy/core": "4.x || 5.x || 6.x || 7.x"
+      },
+      "peerDependenciesMeta": {
+        "@aws-lambda-powertools/jmespath": {
+          "optional": true
+        },
+        "@middy/core": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-1.5.1.tgz",
-      "integrity": "sha512-kBvJR9phGdH5UqtcWyxVMQoZU57liQeVxZCFbDMSAhdlxBbW1pkPBASaKv/FLlX++Tb4TeO1Tj28dox1yL1t+w==",
-      "deprecated": "Version 1.x has reached End-of-Life, please upgrade to 2.x, more info here: https://s12d.com/upgrade-v2",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-2.33.1.tgz",
+      "integrity": "sha512-QtkymyPtLqMuxTcwfHLahw2UOcHeEGISL3kA+5/mdBiHjnQE0qeWZKZ+SzMOwMTWvD2jHYN+K5F/8SODDb6yIQ==",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.5.1"
+        "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws/lambda-invoke-store": "0.2.4"
+      },
+      "peerDependencies": {
+        "@middy/core": "4.x || 5.x || 6.x || 7.x"
+      },
+      "peerDependenciesMeta": {
+        "@middy/core": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/checksums": {
@@ -2871,13 +2893,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/sinon": {
@@ -4487,12 +4509,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5064,9 +5080,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },

--- a/test-harness/src/package.json
+++ b/test-harness/src/package.json
@@ -13,8 +13,9 @@
   "author": "GDS",
   "license": "MIT",
   "dependencies": {
-    "@aws-lambda-powertools/logger": "1.5.1",
-    "@aws-lambda-powertools/metrics": "1.5.1",
+    "@aws-lambda-powertools/commons": "2.33.1",
+    "@aws-lambda-powertools/logger": "2.33.1",
+    "@aws-lambda-powertools/metrics": "2.33.1",
     "@aws-sdk/client-athena": "3.1045.0",
     "@aws-sdk/client-s3": "3.1045.0",
     "@smithy/node-http-handler": "4.0.4",
@@ -23,7 +24,7 @@
   "devDependencies": {
     "@babel/preset-typescript": "7.22.5",
     "@types/aws-lambda": "8.10.148",
-    "@types/node": "20.14.8",
+    "@types/node": "24.0.0",
     "@typescript-eslint/eslint-plugin": "8.56.1",
     "@typescript-eslint/parser": "8.56.1",
     "@vitest/coverage-v8": "4.1.4",
@@ -39,7 +40,7 @@
     ]
   },
   "engines": {
-    "node": "22.*"
+    "node": "24.*"
   },
   "type": "module"
 }

--- a/test-harness/template.yaml
+++ b/test-harness/template.yaml
@@ -58,7 +58,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs24.x
     VpcConfig:
       SecurityGroupIds:
         - !GetAtt LambdaEgressSecurityGroup.GroupId

--- a/traffic-tests/Dockerfile
+++ b/traffic-tests/Dockerfile
@@ -6,7 +6,7 @@ RUN apt install -y curl unzip
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-ENV NODE_MAJOR=22
+ENV NODE_MAJOR=24
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update
 RUN apt-get install nodejs -y


### PR DESCRIPTION
## Proposed changes

### What changed

- Upgraded the repo from Node 22/20 runtime usage to Node 24:
  - Lambda runtimes now use `nodejs24.x`
  - CI workflows now install Node 24
  - Docker images now install Node 24
  - package engines, lockfiles, and `@types/node` were updated for Node 24

- Updated Lambda handler exports that use Powertools decorators so they are explicit async handlers. This avoids Node 24 treating them as deprecated callback-style handlers.

- Updated JWKS encryption handling for Node 24:
  - backend encryption keys are published with `alg: RSA-OAEP-256`
  - IPV stub normalises stale encryption JWK metadata before importing keys with WebCrypto
  - tests were added and updated for the Node 24 encryption key behaviour

- Updated JWT/base64 utility usage and `node:buffer` imports for Node 24 compatibility.

### Why did it change

Node 20 approaching end of life, and the service still had Lambdas running on Node 20 even though build tooling had previously moved forward.

During the Node 24 uplift, two runtime differences needed code changes:

- Node 24 Lambda no longer supports callback-style handlers. Powertools decorators made some handlers appear callback-based, so we now export explicit async wrappers.
- Node 24 WebCrypto is stricter about JWK algorithm metadata. The encryption key must be treated as `RSA-OAEP-256`, not `RS256`.

### Issue tracking

- [KIWI-2670](https://govukverify.atlassian.net/browse/KIWI-2670)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] No README update required

[KIWI-2670]: https://govukverify.atlassian.net/browse/KIWI-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ