### PR TITLE
KIWI-2852 powertools logger v1 to v2 migration fixing splunk log leakage

### DIFF
--- a/src/AbortHandler.ts
+++ b/src/AbortHandler.ts
@@ -25,7 +25,7 @@ export class AbortHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/AccessTokenHandler.ts
+++ b/src/AccessTokenHandler.ts
@@ -24,8 +24,8 @@ export class AccessToken implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/AuthorizationHandler.ts
+++ b/src/AuthorizationHandler.ts
@@ -24,7 +24,7 @@ class AuthorizationHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 				
 		let sessionId: string;

--- a/src/HmrcTokenHandler.ts
+++ b/src/HmrcTokenHandler.ts
@@ -28,7 +28,7 @@ class HmrcTokenHandler implements LambdaInterface {
 	private readonly HMRC_CLIENT_SECRET_SSM_PATH = checkEnvironmentVariable(EnvironmentVariables.HMRC_CLIENT_SECRET_SSM_PATH, logger);
 
 	async handler(): Promise<void> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		
 		try {
 			logger.info("Generating a new HMRC token");
@@ -66,4 +66,3 @@ class HmrcTokenHandler implements LambdaInterface {
 
 export const handlerClass = new HmrcTokenHandler();
 export const lambdaHandler = handlerClass.handler.bind(handlerClass);
-

--- a/src/PartialNameMatchHandler.ts
+++ b/src/PartialNameMatchHandler.ts
@@ -36,8 +36,8 @@ class PartialNameMatchHandler implements LambdaInterface {
 			});
 		}
 
-		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
-		logger.setPersistentLogAttributes({});
+		// clear logger state set by any previous invocation, and add lambda context for this invocation
+		logger.resetKeys();
 		logger.addContext(context);
 
 		const partialMatchesBucketName = checkEnvironmentVariable(EnvironmentVariables.PARTIAL_MATCHES_BUCKET, logger);

--- a/src/PersonInfoHandler.ts
+++ b/src/PersonInfoHandler.ts
@@ -29,7 +29,7 @@ export class PersonInfoHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/PersonInfoKeyHandler.ts
+++ b/src/PersonInfoKeyHandler.ts
@@ -26,7 +26,7 @@ export class PersonInfoKeyHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/SessionHandler.ts
+++ b/src/SessionHandler.ts
@@ -23,7 +23,7 @@ class Session implements LambdaInterface {
 
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/UserInfoHandler.ts
+++ b/src/UserInfoHandler.ts
@@ -26,7 +26,7 @@ class UserInfoHandler implements LambdaInterface {
 
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
 
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/src/VerifyAccountHandler.ts
+++ b/src/VerifyAccountHandler.ts
@@ -28,7 +28,7 @@ export class VerifyAccountHandler implements LambdaInterface {
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
 
 	async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 
 		try {

--- a/test-harness/src/AthenaQueryHandler.ts
+++ b/test-harness/src/AthenaQueryHandler.ts
@@ -46,7 +46,7 @@ class AthenaQueryHandler implements LambdaInterface {
 		event: APIGatewayProxyEvent,
 		context: any
   ): Promise<APIGatewayProxyResult> {
-		logger.setPersistentLogAttributes({});
+		logger.resetKeys();
 		logger.addContext(context);
 		logger.info("Starting AthenaQueryHandler");
 


### PR DESCRIPTION
## Proposed changes

### What changed

Updated Lambda handler logger reset logic for AWS Lambda Powertools Logger v2.

- Added `logger.resetKeys()` at the start of each Lambda handler invocation to clear temporary keys added with `logger.appendKeys()`. ([link](https://github.com/aws-powertools/powertools-lambda-typescript/blob/a3d3147a4629d1bfb8acd932033a683f8fd20a7b/packages/logger/src/Logger.ts#L645))
- Removed deprecated  V1 `logger.setPersistentLogAttributes({})` method 

### Why did it change

After upgrading AWS Lambda Powertools Logger from v1 to v2, temporary keys added with `appendKeys()` are not cleared by resetting persistent log attributes with `logger.setPersistentLogAttributes();`. [link](https://docs.aws.amazon.com/powertools/typescript/2.8.0/api/classes/_aws_lambda_powertools_logger.index.Logger.html#setPersistentLogAttributes:~:text=Logger.ts%3A562-,setPersistentLogAttributes,-setPersistentLog)

Because our keys are not being properly cleared, when in a warm Lambda execution environment, identifiers such as session or journey IDs remain on the shared logger instance and appear in later invocation logs. This change explicitly clears temporary logger keys at the start of each invocation, preventing logger context from leaking between executions without rolling back the Powertools version bump.

### Issue tracking

- [KIWI-2852](https://govukverify.atlassian.net/browse/KIWI-2852)

[KIWI-2852]: https://govukverify.atlassian.net/browse/KIWI-2852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ